### PR TITLE
feat(escrow_contract): implement two-step admin transfer mechanism

### DIFF
--- a/contracts/escrow_contract/lib.rs
+++ b/contracts/escrow_contract/lib.rs
@@ -8,15 +8,50 @@ pub struct EscrowContract;
 
 #[contractimpl]
 impl EscrowContract {
-    /// Initialize the escrow with an amount
     pub fn init(env: Env, sender: Address, amount: i128) {
         sender.require_auth();
         env.storage().instance().set(&Symbol::new(&env, "amount"), &amount);
+        env.storage().instance().set(&Symbol::new(&env, "admin"), &sender);
     }
 
-    /// Retrieve the delivery status for the escrow (Sample cross-contract integration)
     pub fn get_status(_env: Env) -> DeliveryStatus {
         DeliveryStatus::Created
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage().instance()
+            .get(&Symbol::new(&env, "admin"))
+            .unwrap()
+    }
+
+    pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
+        current_admin.require_auth();
+        let stored_admin: Address = env.storage().instance()
+            .get(&Symbol::new(&env, "admin"))
+            .unwrap();
+        if stored_admin != current_admin {
+            panic!("caller is not the admin");
+        }
+        env.storage().instance().set(&Symbol::new(&env, "pending_admin"), &new_admin);
+    }
+
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+        let pending: Address = env.storage().instance()
+            .get(&Symbol::new(&env, "pending_admin"))
+            .unwrap();
+        if pending != new_admin {
+            panic!("caller is not the pending admin");
+        }
+        let old_admin: Address = env.storage().instance()
+            .get(&Symbol::new(&env, "admin"))
+            .unwrap();
+        env.storage().instance().set(&Symbol::new(&env, "admin"), &new_admin);
+        env.storage().instance().remove(&Symbol::new(&env, "pending_admin"));
+        env.events().publish(
+            (Symbol::new(&env, "AdminTransferred"),),
+            (old_admin, new_admin),
+        );
     }
 }
 

--- a/contracts/escrow_contract/test.rs
+++ b/contracts/escrow_contract/test.rs
@@ -6,21 +6,82 @@ use soroban_sdk::{testutils::Address as _, Env};
 #[test]
 fn test_init_and_get_status() {
     let env = Env::default();
-    
-    // Register the contract
     let contract_id = env.register_contract(None, EscrowContract);
     let client = EscrowContractClient::new(&env, &contract_id);
-
-    // Generate a mock sender address
     let sender = Address::generate(&env);
-    
-    // Mock authentication for the sender
     env.mock_all_auths();
-
-    // Call the init function
     client.init(&sender, &1000);
-
-    // Call get_status and verify the result
     let status = client.get_status();
     assert_eq!(status, DeliveryStatus::Created);
+}
+
+#[test]
+fn test_propose_and_accept_admin() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    assert_eq!(client.get_admin(), admin);
+
+    client.propose_admin(&admin, &new_admin);
+    client.accept_admin(&new_admin);
+
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+#[should_panic]
+fn test_accept_admin_rejected_for_non_pending() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let proposed = Address::generate(&env);
+    let other = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    client.propose_admin(&admin, &proposed);
+    // A different address attempts to accept — must panic
+    client.accept_admin(&other);
+}
+
+#[test]
+fn test_admin_cleared_after_transfer() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    client.propose_admin(&admin, &new_admin);
+    client.accept_admin(&new_admin);
+
+    // old admin is no longer the admin
+    assert_ne!(client.get_admin(), admin);
+    // new admin is set
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+fn test_admin_transfer_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    client.propose_admin(&admin, &new_admin);
+    client.accept_admin(&new_admin);
+
+    // At least the AdminTransferred event was published during accept_admin
+    assert!(!env.events().all().is_empty());
 }


### PR DESCRIPTION
## Summary

- Added `propose_admin` so the current admin can nominate a new admin address (stored as `pending_admin` in instance storage)
- Added `accept_admin` so the nominated address can claim the admin role; atomically updates `admin` and clears `pending_admin` on acceptance
- `init` now stores the initializer as the first `admin`
- Added `get_admin` view function needed to verify admin state
- Emits `AdminTransferred { old_admin, new_admin }` event on successful transfer
- Added four unit tests covering: happy-path transfer, non-pending address rejection, atomic state update, and event emission

## Test plan

- [ ] `test_init_and_get_status` — existing test still passes
- [ ] `test_propose_and_accept_admin` — end-to-end two-step transfer succeeds
- [ ] `test_accept_admin_rejected_for_non_pending` — panics when wrong address calls `accept_admin`
- [ ] `test_admin_cleared_after_transfer` — old admin no longer set, new admin confirmed
- [ ] `test_admin_transfer_emits_event` — event published on transfer

Closes #14


