### PR TITLE
implemented TTL and storage ledger extension for escrow

### DIFF
--- a/contracts/escrow_contract/lib.rs
+++ b/contracts/escrow_contract/lib.rs
@@ -3,6 +3,14 @@
 use soroban_sdk::{contract, contractimpl, Env, Symbol, Address};
 use shared_types::DeliveryStatus;
 
+mod constants {
+    // Ledger closes ~every 5 seconds; 17,280 ledgers ≈ 1 day.
+    // Trigger re-extension when fewer than ~30 days of ledgers remain.
+    pub const ESCROW_TTL_THRESHOLD: u32 = 518_400;
+    // Extend to ~90 days to cover the full delivery lifecycle including disputes.
+    pub const ESCROW_TTL_EXTEND_TO: u32 = 1_555_200;
+}
+
 #[contract]
 pub struct EscrowContract;
 
@@ -10,8 +18,18 @@ pub struct EscrowContract;
 impl EscrowContract {
     pub fn init(env: Env, sender: Address, amount: i128) {
         sender.require_auth();
-        env.storage().instance().set(&Symbol::new(&env, "amount"), &amount);
+        let amount_key = Symbol::new(&env, "amount");
+        env.storage().persistent().set(&amount_key, &amount);
+        env.storage().persistent().extend_ttl(
+            &amount_key,
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
         env.storage().instance().set(&Symbol::new(&env, "admin"), &sender);
+        env.storage().instance().extend_ttl(
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
     }
 
     pub fn get_status(_env: Env) -> DeliveryStatus {
@@ -24,6 +42,12 @@ impl EscrowContract {
             .unwrap()
     }
 
+    pub fn get_amount(env: Env) -> i128 {
+        env.storage().persistent()
+            .get(&Symbol::new(&env, "amount"))
+            .unwrap()
+    }
+
     pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
         current_admin.require_auth();
         let stored_admin: Address = env.storage().instance()
@@ -33,6 +57,10 @@ impl EscrowContract {
             panic!("caller is not the admin");
         }
         env.storage().instance().set(&Symbol::new(&env, "pending_admin"), &new_admin);
+        env.storage().instance().extend_ttl(
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
     }
 
     pub fn accept_admin(env: Env, new_admin: Address) {
@@ -48,6 +76,10 @@ impl EscrowContract {
             .unwrap();
         env.storage().instance().set(&Symbol::new(&env, "admin"), &new_admin);
         env.storage().instance().remove(&Symbol::new(&env, "pending_admin"));
+        env.storage().instance().extend_ttl(
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
         env.events().publish(
             (Symbol::new(&env, "AdminTransferred"),),
             (old_admin, new_admin),

--- a/contracts/escrow_contract/test.rs
+++ b/contracts/escrow_contract/test.rs
@@ -85,3 +85,48 @@ fn test_admin_transfer_emits_event() {
     // At least the AdminTransferred event was published during accept_admin
     assert!(!env.events().all().is_empty());
 }
+
+#[test]
+fn test_init_persists_escrow_amount_with_ttl() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let sender = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&sender, &5000);
+
+    // Verifies amount was written to persistent storage and TTL extension did not panic
+    assert_eq!(client.get_amount(), 5000);
+}
+
+#[test]
+fn test_propose_admin_extends_instance_ttl() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    // Verifies instance TTL extension in propose_admin does not panic and state is correct
+    client.propose_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_accept_admin_extends_instance_ttl() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    client.propose_admin(&admin, &new_admin);
+    // Verifies instance TTL extension in accept_admin does not panic and admin is updated
+    client.accept_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}


### PR DESCRIPTION
## Summary

- Defined `ESCROW_TTL_THRESHOLD` (518,400 ledgers ≈ 30 days) and `ESCROW_TTL_EXTEND_TO` (1,555,200 ledgers ≈ 90 days) in a `mod constants` block with inline rationale comments
- Escrow amount is now stored in `persistent()` storage (correct type for escrow records under Stellar's state-rent model) with TTL extended on every write
- Instance storage for admin config (`admin`, `pending_admin`) has TTL extended on every admin action: `init`, `propose_admin`, and `accept_admin`
- Added `get_amount` view function to support persistent storage verification in tests
- Added 3 unit tests covering TTL extension on escrow create and both admin actions

## Test plan

- [ ] `test_init_and_get_status` — existing test still passes
- [ ] `test_propose_and_accept_admin` — still passes with TTL calls added
- [ ] `test_accept_admin_rejected_for_non_pending` — still panics correctly
- [ ] `test_admin_cleared_after_transfer` — still passes
- [ ] `test_admin_transfer_emits_event` — still passes
- [ ] `test_init_persists_escrow_amount_with_ttl` — amount is readable from persistent storage after init
- [ ] `test_propose_admin_extends_instance_ttl` — propose_admin succeeds with TTL extension, state correct
- [ ] `test_accept_admin_extends_instance_ttl` — accept_admin succeeds with TTL extension, admin updated

Closes #15

