### PR TITLE
test(escrow_contract): write integration tests for full escrow lifecycle

### DIFF
--- a/contracts/escrow_contract/lib.rs
+++ b/contracts/escrow_contract/lib.rs
@@ -3,6 +3,14 @@
 use soroban_sdk::{contract, contractimpl, Env, Symbol, Address};
 use shared_types::DeliveryStatus;
 
+mod constants {
+    // Ledger closes ~every 5 seconds; 17,280 ledgers ≈ 1 day.
+    // Trigger re-extension when fewer than ~30 days of ledgers remain.
+    pub const ESCROW_TTL_THRESHOLD: u32 = 518_400;
+    // Extend to ~90 days to cover the full delivery lifecycle including disputes.
+    pub const ESCROW_TTL_EXTEND_TO: u32 = 1_555_200;
+}
+
 #[contract]
 pub struct EscrowContract;
 
@@ -10,8 +18,18 @@ pub struct EscrowContract;
 impl EscrowContract {
     pub fn init(env: Env, sender: Address, amount: i128) {
         sender.require_auth();
-        env.storage().instance().set(&Symbol::new(&env, "amount"), &amount);
+        let amount_key = Symbol::new(&env, "amount");
+        env.storage().persistent().set(&amount_key, &amount);
+        env.storage().persistent().extend_ttl(
+            &amount_key,
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
         env.storage().instance().set(&Symbol::new(&env, "admin"), &sender);
+        env.storage().instance().extend_ttl(
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
     }
 
     pub fn get_status(_env: Env) -> DeliveryStatus {
@@ -24,6 +42,12 @@ impl EscrowContract {
             .unwrap()
     }
 
+    pub fn get_amount(env: Env) -> i128 {
+        env.storage().persistent()
+            .get(&Symbol::new(&env, "amount"))
+            .unwrap()
+    }
+
     pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
         current_admin.require_auth();
         let stored_admin: Address = env.storage().instance()
@@ -33,6 +57,10 @@ impl EscrowContract {
             panic!("caller is not the admin");
         }
         env.storage().instance().set(&Symbol::new(&env, "pending_admin"), &new_admin);
+        env.storage().instance().extend_ttl(
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
     }
 
     pub fn accept_admin(env: Env, new_admin: Address) {
@@ -48,6 +76,10 @@ impl EscrowContract {
             .unwrap();
         env.storage().instance().set(&Symbol::new(&env, "admin"), &new_admin);
         env.storage().instance().remove(&Symbol::new(&env, "pending_admin"));
+        env.storage().instance().extend_ttl(
+            constants::ESCROW_TTL_THRESHOLD,
+            constants::ESCROW_TTL_EXTEND_TO,
+        );
         env.events().publish(
             (Symbol::new(&env, "AdminTransferred"),),
             (old_admin, new_admin),

--- a/contracts/escrow_contract/lib.rs
+++ b/contracts/escrow_contract/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Env, Symbol, Address};
+use soroban_sdk::{contract, contractimpl, token, Env, Symbol, Address};
 use shared_types::DeliveryStatus;
 
 mod constants {
@@ -9,6 +9,58 @@ mod constants {
     pub const ESCROW_TTL_THRESHOLD: u32 = 518_400;
     // Extend to ~90 days to cover the full delivery lifecycle including disputes.
     pub const ESCROW_TTL_EXTEND_TO: u32 = 1_555_200;
+}
+
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum EscrowStatus {
+    Pending,
+    Released,
+    Refunded,
+    Disputed,
+}
+
+#[soroban_sdk::contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EscrowRecord {
+    pub sender: Address,
+    pub driver: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub status: EscrowStatus,
+}
+
+#[soroban_sdk::contracttype]
+pub enum DataKey {
+    Escrow(u64),
+}
+
+fn load_escrow(env: &Env, delivery_id: u64) -> EscrowRecord {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Escrow(delivery_id))
+        .unwrap()
+}
+
+fn save_escrow(env: &Env, delivery_id: u64, record: &EscrowRecord) {
+    let key = DataKey::Escrow(delivery_id);
+    env.storage().persistent().set(&key, record);
+    env.storage().persistent().extend_ttl(
+        &key,
+        constants::ESCROW_TTL_THRESHOLD,
+        constants::ESCROW_TTL_EXTEND_TO,
+    );
+}
+
+fn require_admin(env: &Env, caller: &Address) {
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&Symbol::new(env, "admin"))
+        .unwrap();
+    if *caller != admin {
+        panic!("caller is not the admin");
+    }
 }
 
 #[contract]
@@ -37,26 +89,32 @@ impl EscrowContract {
     }
 
     pub fn get_admin(env: Env) -> Address {
-        env.storage().instance()
+        env.storage()
+            .instance()
             .get(&Symbol::new(&env, "admin"))
             .unwrap()
     }
 
     pub fn get_amount(env: Env) -> i128 {
-        env.storage().persistent()
+        env.storage()
+            .persistent()
             .get(&Symbol::new(&env, "amount"))
             .unwrap()
     }
 
     pub fn propose_admin(env: Env, current_admin: Address, new_admin: Address) {
         current_admin.require_auth();
-        let stored_admin: Address = env.storage().instance()
+        let stored_admin: Address = env
+            .storage()
+            .instance()
             .get(&Symbol::new(&env, "admin"))
             .unwrap();
         if stored_admin != current_admin {
             panic!("caller is not the admin");
         }
-        env.storage().instance().set(&Symbol::new(&env, "pending_admin"), &new_admin);
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "pending_admin"), &new_admin);
         env.storage().instance().extend_ttl(
             constants::ESCROW_TTL_THRESHOLD,
             constants::ESCROW_TTL_EXTEND_TO,
@@ -65,17 +123,25 @@ impl EscrowContract {
 
     pub fn accept_admin(env: Env, new_admin: Address) {
         new_admin.require_auth();
-        let pending: Address = env.storage().instance()
+        let pending: Address = env
+            .storage()
+            .instance()
             .get(&Symbol::new(&env, "pending_admin"))
             .unwrap();
         if pending != new_admin {
             panic!("caller is not the pending admin");
         }
-        let old_admin: Address = env.storage().instance()
+        let old_admin: Address = env
+            .storage()
+            .instance()
             .get(&Symbol::new(&env, "admin"))
             .unwrap();
-        env.storage().instance().set(&Symbol::new(&env, "admin"), &new_admin);
-        env.storage().instance().remove(&Symbol::new(&env, "pending_admin"));
+        env.storage()
+            .instance()
+            .set(&Symbol::new(&env, "admin"), &new_admin);
+        env.storage()
+            .instance()
+            .remove(&Symbol::new(&env, "pending_admin"));
         env.storage().instance().extend_ttl(
             constants::ESCROW_TTL_THRESHOLD,
             constants::ESCROW_TTL_EXTEND_TO,
@@ -84,6 +150,133 @@ impl EscrowContract {
             (Symbol::new(&env, "AdminTransferred"),),
             (old_admin, new_admin),
         );
+    }
+
+    // ── Escrow lifecycle ──────────────────────────────────────────────────────
+
+    pub fn create_escrow(
+        env: Env,
+        sender: Address,
+        driver: Address,
+        delivery_id: u64,
+        token: Address,
+        amount: i128,
+    ) {
+        sender.require_auth();
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Escrow(delivery_id))
+        {
+            panic!("escrow already exists for this delivery_id");
+        }
+        token::Client::new(&env, &token).transfer(
+            &sender,
+            &env.current_contract_address(),
+            &amount,
+        );
+        save_escrow(
+            &env,
+            delivery_id,
+            &EscrowRecord {
+                sender,
+                driver,
+                token,
+                amount,
+                status: EscrowStatus::Pending,
+            },
+        );
+        env.events()
+            .publish((Symbol::new(&env, "EscrowCreated"), delivery_id), amount);
+    }
+
+    pub fn release_escrow(env: Env, caller: Address, delivery_id: u64) {
+        caller.require_auth();
+        require_admin(&env, &caller);
+        let mut record = load_escrow(&env, delivery_id);
+        if record.status != EscrowStatus::Pending {
+            panic!("escrow is not in pending state");
+        }
+        token::Client::new(&env, &record.token).transfer(
+            &env.current_contract_address(),
+            &record.driver,
+            &record.amount,
+        );
+        record.status = EscrowStatus::Released;
+        save_escrow(&env, delivery_id, &record);
+        env.events()
+            .publish((Symbol::new(&env, "EscrowReleased"), delivery_id), record.amount);
+    }
+
+    pub fn refund_escrow(env: Env, caller: Address, delivery_id: u64) {
+        caller.require_auth();
+        require_admin(&env, &caller);
+        let mut record = load_escrow(&env, delivery_id);
+        if record.status != EscrowStatus::Pending {
+            panic!("escrow is not in pending state");
+        }
+        token::Client::new(&env, &record.token).transfer(
+            &env.current_contract_address(),
+            &record.sender,
+            &record.amount,
+        );
+        record.status = EscrowStatus::Refunded;
+        save_escrow(&env, delivery_id, &record);
+        env.events()
+            .publish((Symbol::new(&env, "EscrowRefunded"), delivery_id), record.amount);
+    }
+
+    pub fn raise_dispute(env: Env, caller: Address, delivery_id: u64) {
+        caller.require_auth();
+        let mut record = load_escrow(&env, delivery_id);
+        if caller != record.sender {
+            panic!("only the escrow sender can raise a dispute");
+        }
+        if record.status != EscrowStatus::Pending {
+            panic!("escrow is not in pending state");
+        }
+        record.status = EscrowStatus::Disputed;
+        save_escrow(&env, delivery_id, &record);
+        env.events()
+            .publish((Symbol::new(&env, "DisputeRaised"), delivery_id), delivery_id);
+    }
+
+    pub fn resolve_dispute(
+        env: Env,
+        caller: Address,
+        delivery_id: u64,
+        release_to_driver: bool,
+    ) {
+        caller.require_auth();
+        require_admin(&env, &caller);
+        let mut record = load_escrow(&env, delivery_id);
+        if record.status != EscrowStatus::Disputed {
+            panic!("escrow is not in disputed state");
+        }
+        if release_to_driver {
+            token::Client::new(&env, &record.token).transfer(
+                &env.current_contract_address(),
+                &record.driver,
+                &record.amount,
+            );
+            record.status = EscrowStatus::Released;
+        } else {
+            token::Client::new(&env, &record.token).transfer(
+                &env.current_contract_address(),
+                &record.sender,
+                &record.amount,
+            );
+            record.status = EscrowStatus::Refunded;
+        }
+        save_escrow(&env, delivery_id, &record);
+        env.events().publish(
+            (Symbol::new(&env, "DisputeResolved"), delivery_id),
+            release_to_driver,
+        );
+    }
+
+    pub fn get_escrow_record(env: Env, delivery_id: u64) -> EscrowRecord {
+        load_escrow(&env, delivery_id)
     }
 }
 

--- a/contracts/escrow_contract/test.rs
+++ b/contracts/escrow_contract/test.rs
@@ -85,3 +85,48 @@ fn test_admin_transfer_emits_event() {
     // At least the AdminTransferred event was published during accept_admin
     assert!(!env.events().all().is_empty());
 }
+
+#[test]
+fn test_init_persists_escrow_amount_with_ttl() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let sender = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&sender, &5000);
+
+    // Verifies amount was written to persistent storage and TTL extension did not panic
+    assert_eq!(client.get_amount(), 5000);
+}
+
+#[test]
+fn test_propose_admin_extends_instance_ttl() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    // Verifies instance TTL extension in propose_admin does not panic and state is correct
+    client.propose_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_accept_admin_extends_instance_ttl() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, EscrowContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    env.mock_all_auths();
+
+    client.init(&admin, &1000);
+    client.propose_admin(&admin, &new_admin);
+    // Verifies instance TTL extension in accept_admin does not panic and admin is updated
+    client.accept_admin(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}

--- a/contracts/escrow_contract/test.rs
+++ b/contracts/escrow_contract/test.rs
@@ -1,7 +1,35 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, Env};
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{Client as TokenClient, StellarAssetClient},
+    Address, Env,
+};
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup_env() -> (Env, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, EscrowContract);
+    (env, contract_id)
+}
+
+fn setup_token(env: &Env, token_admin: &Address) -> Address {
+    env.register_stellar_asset_contract_v2(token_admin.clone())
+        .address()
+}
+
+fn mint(env: &Env, token_addr: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token_addr).mint(to, &amount);
+}
+
+fn balance(env: &Env, token_addr: &Address, of: &Address) -> i128 {
+    TokenClient::new(env, token_addr).balance(of)
+}
+
+// ── original tests (preserved) ───────────────────────────────────────────────
 
 #[test]
 fn test_init_and_get_status() {
@@ -63,9 +91,7 @@ fn test_admin_cleared_after_transfer() {
     client.propose_admin(&admin, &new_admin);
     client.accept_admin(&new_admin);
 
-    // old admin is no longer the admin
     assert_ne!(client.get_admin(), admin);
-    // new admin is set
     assert_eq!(client.get_admin(), new_admin);
 }
 
@@ -82,7 +108,6 @@ fn test_admin_transfer_emits_event() {
     client.propose_admin(&admin, &new_admin);
     client.accept_admin(&new_admin);
 
-    // At least the AdminTransferred event was published during accept_admin
     assert!(!env.events().all().is_empty());
 }
 
@@ -96,7 +121,6 @@ fn test_init_persists_escrow_amount_with_ttl() {
 
     client.init(&sender, &5000);
 
-    // Verifies amount was written to persistent storage and TTL extension did not panic
     assert_eq!(client.get_amount(), 5000);
 }
 
@@ -110,7 +134,6 @@ fn test_propose_admin_extends_instance_ttl() {
     env.mock_all_auths();
 
     client.init(&admin, &1000);
-    // Verifies instance TTL extension in propose_admin does not panic and state is correct
     client.propose_admin(&admin, &new_admin);
     assert_eq!(client.get_admin(), admin);
 }
@@ -126,7 +149,272 @@ fn test_accept_admin_extends_instance_ttl() {
 
     client.init(&admin, &1000);
     client.propose_admin(&admin, &new_admin);
-    // Verifies instance TTL extension in accept_admin does not panic and admin is updated
     client.accept_admin(&new_admin);
     assert_eq!(client.get_admin(), new_admin);
+}
+
+// ── lifecycle integration tests ───────────────────────────────────────────────
+
+#[test]
+fn test_happy_path_create_and_release() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 1000);
+
+    client.create_escrow(&sender, &driver, &1u64, &token_addr, &1000);
+
+    assert_eq!(balance(&env, &token_addr, &sender), 0);
+    assert_eq!(balance(&env, &token_addr, &contract_id), 1000);
+
+    let record = client.get_escrow_record(&1u64);
+    assert_eq!(record.status, EscrowStatus::Pending);
+
+    client.release_escrow(&admin, &1u64);
+
+    assert_eq!(balance(&env, &token_addr, &driver), 1000);
+    assert_eq!(balance(&env, &token_addr, &contract_id), 0);
+    assert_eq!(client.get_escrow_record(&1u64).status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_refund_path_restores_sender_balance() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 500);
+
+    client.create_escrow(&sender, &driver, &2u64, &token_addr, &500);
+
+    assert_eq!(balance(&env, &token_addr, &sender), 0);
+
+    client.refund_escrow(&admin, &2u64);
+
+    assert_eq!(balance(&env, &token_addr, &sender), 500);
+    assert_eq!(balance(&env, &token_addr, &contract_id), 0);
+    assert_eq!(client.get_escrow_record(&2u64).status, EscrowStatus::Refunded);
+}
+
+#[test]
+fn test_dispute_resolved_to_driver() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 750);
+
+    client.create_escrow(&sender, &driver, &3u64, &token_addr, &750);
+    client.raise_dispute(&sender, &3u64);
+
+    assert_eq!(client.get_escrow_record(&3u64).status, EscrowStatus::Disputed);
+
+    client.resolve_dispute(&admin, &3u64, &true);
+
+    assert_eq!(balance(&env, &token_addr, &driver), 750);
+    assert_eq!(balance(&env, &token_addr, &sender), 0);
+    assert_eq!(client.get_escrow_record(&3u64).status, EscrowStatus::Released);
+}
+
+#[test]
+fn test_dispute_resolved_to_sender() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 300);
+
+    client.create_escrow(&sender, &driver, &4u64, &token_addr, &300);
+    client.raise_dispute(&sender, &4u64);
+    client.resolve_dispute(&admin, &4u64, &false);
+
+    assert_eq!(balance(&env, &token_addr, &sender), 300);
+    assert_eq!(balance(&env, &token_addr, &driver), 0);
+    assert_eq!(client.get_escrow_record(&4u64).status, EscrowStatus::Refunded);
+}
+
+#[test]
+#[should_panic]
+fn test_release_by_non_admin_rejected() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 200);
+    client.create_escrow(&sender, &driver, &5u64, &token_addr, &200);
+
+    client.release_escrow(&attacker, &5u64);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_by_non_admin_rejected() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 200);
+    client.create_escrow(&sender, &driver, &6u64, &token_addr, &200);
+
+    client.refund_escrow(&attacker, &6u64);
+}
+
+#[test]
+#[should_panic]
+fn test_raise_dispute_by_non_sender_rejected() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 200);
+    client.create_escrow(&sender, &driver, &7u64, &token_addr, &200);
+
+    client.raise_dispute(&attacker, &7u64);
+}
+
+#[test]
+#[should_panic]
+fn test_resolve_dispute_by_non_admin_rejected() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 200);
+    client.create_escrow(&sender, &driver, &8u64, &token_addr, &200);
+    client.raise_dispute(&sender, &8u64);
+
+    client.resolve_dispute(&attacker, &8u64, &true);
+}
+
+#[test]
+#[should_panic]
+fn test_duplicate_delivery_id_rejected() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 2000);
+    client.create_escrow(&sender, &driver, &9u64, &token_addr, &1000);
+
+    client.create_escrow(&sender, &driver, &9u64, &token_addr, &1000);
+}
+
+#[test]
+#[should_panic]
+fn test_release_on_already_released_rejected() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 400);
+    client.create_escrow(&sender, &driver, &10u64, &token_addr, &400);
+    client.release_escrow(&admin, &10u64);
+
+    client.release_escrow(&admin, &10u64);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_on_released_escrow_rejected() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 400);
+    client.create_escrow(&sender, &driver, &11u64, &token_addr, &400);
+    client.release_escrow(&admin, &11u64);
+
+    client.refund_escrow(&admin, &11u64);
+}
+
+#[test]
+fn test_lifecycle_events_emitted() {
+    let (env, contract_id) = setup_env();
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token_addr = setup_token(&env, &token_admin);
+
+    client.init(&admin, &0);
+    mint(&env, &token_addr, &sender, 600);
+
+    client.create_escrow(&sender, &driver, &12u64, &token_addr, &600);
+    client.raise_dispute(&sender, &12u64);
+    client.resolve_dispute(&admin, &12u64, &true);
+
+    assert!(!env.events().all().is_empty());
 }


### PR DESCRIPTION
## Summary

- Implemented the escrow lifecycle functions required for the tests to compile: `create_escrow`, `release_escrow`, `refund_escrow`, `raise_dispute`, `resolve_dispute`, and `get_escrow_record`
- Added `EscrowStatus` and `EscrowRecord` contract types and a typed `DataKey::Escrow(u64)` storage key
- Every persistent write calls `extend_ttl` via the constants defined in #15
- Wrote 12 integration tests covering: happy-path create→release (driver balance asserted), refund path (sender balance restored), dispute resolved to driver, dispute resolved to sender, all four unauthorized-caller failure modes, duplicate delivery ID rejection, invalid state transitions (double-release, release-then-refund), and event emission across the full dispute lifecycle
- All tests run with `cargo test` against the Soroban mock environment — no testnet access required

## Test plan

- [ ] `test_happy_path_create_and_release` — token flows to driver, contract balance zeroed
- [ ] `test_refund_path_restores_sender_balance` — sender gets tokens back
- [ ] `test_dispute_resolved_to_driver` — admin awards driver
- [ ] `test_dispute_resolved_to_sender` — admin refunds sender
- [ ] `test_release_by_non_admin_rejected` — panics
- [ ] `test_refund_by_non_admin_rejected` — panics
- [ ] `test_raise_dispute_by_non_sender_rejected` — panics
- [ ] `test_resolve_dispute_by_non_admin_rejected` — panics
- [ ] `test_duplicate_delivery_id_rejected` — panics
- [ ] `test_release_on_already_released_rejected` — panics
- [ ] `test_refund_on_released_escrow_rejected` — panics
- [ ] `test_lifecycle_events_emitted` — events vec non-empty

Closes #16

