### PR TITLE
Implement `assign_driver` for delivery contract

### DIFF
--- a/contracts/delivery_contract/lib.rs
+++ b/contracts/delivery_contract/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-
+ 
 use soroban_sdk::{
     contract, contractimpl, contracttype, Address, Env, Symbol,
 };

--- a/contracts/delivery_contract/lib.rs
+++ b/contracts/delivery_contract/lib.rs
@@ -1,22 +1,102 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, Env, String};
-use shared_types::{DeliveryDetails, DeliveryStatus};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Address, Env, Symbol,
+};
+
+pub type DeliveryId = u64;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DeliveryStatus {
+    Pending,
+    Active,
+    Completed,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DeliveryRecord {
+    pub driver: Option<Address>,
+    pub status: DeliveryStatus,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Delivery(DeliveryId),
+    Admin,
+}
 
 #[contract]
 pub struct DeliveryContract;
 
 #[contractimpl]
 impl DeliveryContract {
-    /// Create a new delivery record (Sample cross-contract integration using shared_types)
-    pub fn create_delivery(_env: Env, id: u64, driver: String) -> DeliveryDetails {
-        DeliveryDetails {
-            id,
-            driver,
-            status: DeliveryStatus::Created,
+    pub fn init_admin(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn create_delivery(env: Env, delivery_id: DeliveryId) {
+        let record = DeliveryRecord {
+            driver: None,
+            status: DeliveryStatus::Pending,
+        };
+        env.storage().persistent().set(&DataKey::Delivery(delivery_id), &record);
+    }
+
+    pub fn assign_driver(
+        env: Env,
+        caller: Address,
+        delivery_id: DeliveryId,
+        driver: Address,
+    ) {
+        caller.require_auth();
+
+        let is_admin = Self::is_admin(&env, &caller);
+        let is_self_assignment = caller == driver;
+
+        if !is_admin && !is_self_assignment {
+            panic!("NotAuthorized");
+        }
+
+        let key = DataKey::Delivery(delivery_id);
+        let mut delivery: DeliveryRecord = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic!("DeliveryNotFound"));
+
+        if delivery.status != DeliveryStatus::Pending {
+            panic!("InvalidState");
+        }
+
+        delivery.driver = Some(driver.clone());
+        delivery.status = DeliveryStatus::Active;
+
+        env.storage().persistent().set(&key, &delivery);
+
+        // Extend TTL: ~30 days
+        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+
+        env.events().publish(
+            (Symbol::new(&env, "driver_assigned"),),
+            (delivery_id, driver),
+        );
+    }
+
+    fn is_admin(env: &Env, caller: &Address) -> bool {
+        if let Some(admin) = env.storage().instance().get::<_, Address>(&DataKey::Admin) {
+            admin == *caller
+        } else {
+            false
         }
     }
 }
 
 #[cfg(test)]
 mod test;
+

--- a/contracts/delivery_contract/test.rs
+++ b/contracts/delivery_contract/test.rs
@@ -1,24 +1,107 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{Env, String};
+use soroban_sdk::{testutils::{Address as _, Events}, Address, Env, Symbol, TryFromVal};
 
-#[test]
-fn test_create_delivery() {
+fn setup_test() -> (Env, DeliveryContractClient<'static>, Address, Address, Address) {
     let env = Env::default();
-    
-    // Register the contract
-    let contract_id = env.register_contract(None, DeliveryContract);
+    env.mock_all_auths();
+
+    let contract_id = env.register(DeliveryContract, ());
     let client = DeliveryContractClient::new(&env, &contract_id);
 
-    // Create mock parameters
-    let driver_name = String::from_str(&env, "DriverBob");
-    
-    // Call create_delivery
-    let delivery = client.create_delivery(&1, &driver_name);
+    let admin = Address::generate(&env);
+    let driver = Address::generate(&env);
+    let unauthorized = Address::generate(&env);
 
-    // Assert the properties of the created delivery
-    assert_eq!(delivery.id, 1);
-    assert_eq!(delivery.driver, driver_name);
-    // assert_eq!(delivery.status, DeliveryStatus::Created);
+    client.init_admin(&admin);
+
+    (env, client, admin, driver, unauthorized)
 }
+
+#[test]
+fn test_successful_assignment_by_admin() {
+    let (env, client, admin, driver, _) = setup_test();
+
+    let delivery_id = 1;
+    client.create_delivery(&delivery_id);
+
+    client.assign_driver(&admin, &delivery_id, &driver);
+
+    // Verify events
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    
+    assert_eq!(
+        last_event.0, // contract_id
+        client.address.clone()
+    );
+
+    let topic0: Symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(topic0, Symbol::new(&env, "driver_assigned"));
+
+    let data: (DeliveryId, Address) = <(DeliveryId, Address)>::try_from_val(&env, &last_event.2).unwrap();
+    assert_eq!(data, (delivery_id, driver.clone()));
+
+    let delivery: DeliveryRecord = env
+        .as_contract(&client.address, || {
+            env.storage()
+                .persistent()
+                .get(&DataKey::Delivery(delivery_id))
+                .unwrap()
+        });
+
+    assert_eq!(delivery.driver, Some(driver.clone()));
+    assert_eq!(delivery.status, DeliveryStatus::Active);
+}
+
+#[test]
+fn test_successful_self_assignment_by_driver() {
+    let (env, client, _, driver, _) = setup_test();
+
+    let delivery_id = 2;
+    client.create_delivery(&delivery_id);
+
+    client.assign_driver(&driver, &delivery_id, &driver);
+
+    let delivery: DeliveryRecord = env
+        .as_contract(&client.address, || {
+            env.storage()
+                .persistent()
+                .get(&DataKey::Delivery(delivery_id))
+                .unwrap()
+        });
+
+    assert_eq!(delivery.driver, Some(driver));
+    assert_eq!(delivery.status, DeliveryStatus::Active);
+}
+
+#[test]
+#[should_panic(expected = "NotAuthorized")]
+fn test_unauthorized_caller_rejected() {
+    let (_env, client, _, driver, unauthorized) = setup_test();
+
+    let delivery_id = 3;
+    client.create_delivery(&delivery_id);
+
+    client.assign_driver(&unauthorized, &delivery_id, &driver);
+}
+
+#[test]
+#[should_panic(expected = "InvalidState")]
+fn test_assignment_when_status_not_pending() {
+    let (env, client, admin, driver, _) = setup_test();
+
+    let delivery_id = 4;
+    client.create_delivery(&delivery_id);
+
+    // First assignment changes status to Active
+    client.assign_driver(&admin, &delivery_id, &driver);
+
+    // Second assignment should fail because status is Active
+    let another_driver = Address::generate(&env);
+    client.assign_driver(&admin, &delivery_id, &another_driver);
+}
+
+
+

--- a/contracts/delivery_contract/test.rs
+++ b/contracts/delivery_contract/test.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-
+ 
 use super::*;
 use soroban_sdk::{testutils::{Address as _, Events}, Address, Env, Symbol, TryFromVal};
 

--- a/contracts/shared_types/lib.rs
+++ b/contracts/shared_types/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-
+ 
 use soroban_sdk::{contracttype, String};
 
 // Event topic constants for on-chain event tracking

--- a/contracts/shared_types/lib.rs
+++ b/contracts/shared_types/lib.rs
@@ -1,31 +1,33 @@
 #![no_std]
 
-use soroban_sdk::{contracttype, String, symbol_short};
+use soroban_sdk::{contracttype, String};
 
 // Event topic constants for on-chain event tracking
 pub mod events {
-    use soroban_sdk::Symbol;
+    use soroban_sdk::{Env, Symbol};
 
-    pub fn escrow_funded() -> Symbol {
-        symbol_short!("escrow_funded")
+    pub fn escrow_funded(env: &Env) -> Symbol {
+        Symbol::new(env, "escrow_funded")
     }
 
-    pub fn escrow_released() -> Symbol {
-        symbol_short!("escrow_released")
+    pub fn escrow_released(env: &Env) -> Symbol {
+        Symbol::new(env, "escrow_released")
     }
 
-    pub fn escrow_refunded() -> Symbol {
-        symbol_short!("escrow_refunded")
+    pub fn escrow_refunded(env: &Env) -> Symbol {
+        Symbol::new(env, "escrow_refunded")
     }
 
-    pub fn delivery_disputed() -> Symbol {
-        symbol_short!("delivery_disputed")
+    pub fn delivery_disputed(env: &Env) -> Symbol {
+        Symbol::new(env, "delivery_disputed")
     }
 
-    pub fn dispute_resolved() -> Symbol {
-        symbol_short!("dispute_resolved")
+    pub fn dispute_resolved(env: &Env) -> Symbol {
+        Symbol::new(env, "dispute_resolved")
     }
 }
+
+
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Closes #21

### Description
This PR introduces the secure `assign_driver` function in the `delivery_contract` to handle driver assignments for deliveries. 

### Key Changes
* **Access Control**: Enforced `require_auth()`, restricting callers to either an Admin or the Driver themselves (self-assignment).
* **State Machine**: Validated that assignments can only occur when the delivery is in a `Pending` state, transitioning it to `Active`.
* **Storage & Events**: Extended storage TTL (~30 days) and emitted the `driver_assigned` event upon successful assignment.
* **Testing**: Added comprehensive unit tests covering successful admin/driver assignments, unauthorized rejections, and invalid state panics.
* **Shared Types**: Fixed event symbol length limits in the `shared_types` crate.

### Testing
- [x] `cargo test -p delivery_contract` passes successfully.