### PR TITLE
Feat/delivery contract initialization

### DIFF
--- a/contracts/delivery_contract/lib.rs
+++ b/contracts/delivery_contract/lib.rs
@@ -80,6 +80,7 @@ impl DeliveryContract {
             created_at: env.ledger().timestamp(),
             delivered_at: None,
         };
+        
 
         let key = DataKey::Delivery(delivery_id);
         env.storage().persistent().set(&key, &record);

--- a/contracts/delivery_contract/lib.rs
+++ b/contracts/delivery_contract/lib.rs
@@ -48,19 +48,18 @@ pub struct DeliveryContract;
 
 #[contractimpl]
 impl DeliveryContract {
-    pub fn init_admin(env: Env, admin: Address) {
+    pub fn init(env: Env, admin: Address, escrow_contract: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
-            panic!("already initialized");
+            panic!("AlreadyInitialized");
         }
         env.storage().instance().set(&DataKey::Admin, &admin);
-    }
+        env.storage().instance().set(&DataKey::EscrowContract, &escrow_contract);
+        env.storage().persistent().set(&DataKey::DeliveryCounter, &0u64);
 
-    pub fn set_escrow_contract(env: Env, admin: Address, escrow: Address) {
-        admin.require_auth();
-        if !Self::is_admin(&env, &admin) {
-            panic!("NotAuthorized");
-        }
-        env.storage().instance().set(&DataKey::EscrowContract, &escrow);
+        env.events().publish(
+            (Symbol::new(&env, "DeliveryContractInitialized"),),
+            (admin, escrow_contract),
+        );
     }
 
     pub fn create_delivery(env: Env, sender: Address, metadata: DeliveryMetadata) -> DeliveryId {

--- a/contracts/delivery_contract/test.rs
+++ b/contracts/delivery_contract/test.rs
@@ -44,6 +44,7 @@ fn test_successful_assignment_by_admin() {
     let delivery_id = client.create_delivery(&sender, &metadata);
 
     client.assign_driver(&admin, &delivery_id, &driver);
+    
 
     // Verify events
     let events = env.events().all();

--- a/contracts/delivery_contract/test.rs
+++ b/contracts/delivery_contract/test.rs
@@ -4,6 +4,20 @@ extern crate std;
 use super::*;
 use soroban_sdk::{testutils::{Address as _, Events}, Address, Env, Symbol, TryFromVal};
 
+// --- Escrow Mock ---
+#[contract]
+pub struct MockEscrow;
+
+#[contractimpl]
+impl MockEscrow {
+    pub fn refund_escrow(_env: Env, delivery_id: DeliveryId) {
+        // We can simulate failure if delivery_id is a specific value
+        if delivery_id == 999 {
+            panic!("Escrow failure simulated");
+        }
+    }
+}
+
 fn setup_test() -> (Env, DeliveryContractClient<'static>, Address, Address, Address) {
     let env = Env::default();
     env.mock_all_auths();
@@ -15,7 +29,8 @@ fn setup_test() -> (Env, DeliveryContractClient<'static>, Address, Address, Addr
     let driver = Address::generate(&env);
     let unauthorized = Address::generate(&env);
 
-    client.init_admin(&admin);
+    let escrow_id = env.register(MockEscrow, ());
+    client.init(&admin, &escrow_id);
 
     (env, client, admin, driver, unauthorized)
 }
@@ -109,25 +124,9 @@ fn test_assignment_when_status_not_pending() {
     client.assign_driver(&admin, &delivery_id, &another_driver);
 }
 
-// --- Escrow Mock ---
-#[contract]
-pub struct MockEscrow;
-
-#[contractimpl]
-impl MockEscrow {
-    pub fn refund_escrow(_env: Env, delivery_id: DeliveryId) {
-        // We can simulate failure if delivery_id is a specific value
-        if delivery_id == 999 {
-            panic!("Escrow failure simulated");
-        }
-    }
-}
-
 #[test]
 fn test_cancel_delivery_pending() {
     let (env, client, admin, _, _) = setup_test();
-    let escrow_id = env.register(MockEscrow, ());
-    client.set_escrow_contract(&admin, &escrow_id);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
     let metadata = DeliveryMetadata { recipient: recipient.clone() };
@@ -149,8 +148,6 @@ fn test_cancel_delivery_pending() {
 #[test]
 fn test_cancel_delivery_active() {
     let (env, client, admin, driver, _) = setup_test();
-    let escrow_id = env.register(MockEscrow, ());
-    client.set_escrow_contract(&admin, &escrow_id);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
     let metadata = DeliveryMetadata { recipient: recipient.clone() };
@@ -174,8 +171,6 @@ fn test_cancel_delivery_active() {
 #[should_panic(expected = "NotAuthorized")]
 fn test_cancel_delivery_unauthorized() {
     let (env, client, admin, _, unauthorized) = setup_test();
-    let escrow_id = env.register(MockEscrow, ());
-    client.set_escrow_contract(&admin, &escrow_id);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
     let metadata = DeliveryMetadata { recipient: recipient.clone() };
@@ -188,8 +183,6 @@ fn test_cancel_delivery_unauthorized() {
 #[should_panic(expected = "InvalidState")]
 fn test_cancel_delivery_invalid_state() {
     let (env, client, admin, _, _) = setup_test();
-    let escrow_id = env.register(MockEscrow, ());
-    client.set_escrow_contract(&admin, &escrow_id);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
     let metadata = DeliveryMetadata { recipient: recipient.clone() };
@@ -205,8 +198,6 @@ fn test_cancel_delivery_invalid_state() {
 #[should_panic(expected = "Escrow failure simulated")]
 fn test_cancel_delivery_escrow_failure() {
     let (env, client, admin, _, _) = setup_test();
-    let escrow_id = env.register(MockEscrow, ());
-    client.set_escrow_contract(&admin, &escrow_id);
     let sender = Address::generate(&env);
     let recipient = Address::generate(&env);
     let metadata = DeliveryMetadata { recipient: recipient.clone() };
@@ -266,4 +257,44 @@ fn test_create_delivery_incrementing_ids_and_persistence() {
     assert_eq!(id1, 1);
     assert_eq!(id2, 2);
     assert_eq!(id3, 3);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyInitialized")]
+fn test_double_init() {
+    let (env, client, admin, _, _) = setup_test();
+    let escrow = Address::generate(&env);
+    client.init(&admin, &escrow);
+}
+
+#[test]
+fn test_init_state_and_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(DeliveryContract, ());
+    let client = DeliveryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let escrow = Address::generate(&env);
+
+    client.init(&admin, &escrow);
+
+    // Verify counter initialized
+    let counter: u64 = env.as_contract(&contract_id, || {
+        env.storage().persistent().get(&DataKey::DeliveryCounter).unwrap()
+    });
+    assert_eq!(counter, 0);
+
+    // Verify event
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    
+    assert_eq!(last_event.0, contract_id);
+
+    let topic0: Symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(topic0, Symbol::new(&env, "DeliveryContractInitialized"));
+
+    let data: (Address, Address) = <(Address, Address)>::try_from_val(&env, &last_event.2).unwrap();
+    assert_eq!(data, (admin, escrow));
 }


### PR DESCRIPTION
Closes #19 


## Description
This PR implements the unified `init` function for the Delivery Contract, establishing the essential cross-contract link to the Escrow contract upon instantiation. It refactors the previous fragmented approach by replacing `init_admin` and `set_escrow_contract` with a single, atomic initialization path.

## Summary of Work Done
- Implemented `init(env: Env, admin: Address, escrow_contract: Address)` to store both administrative and escrow contract addresses dynamically inside instance storage.
- Enforced an `AlreadyInitialized` panic to guarantee the contract cannot be re-initialized.
- Successfully seeded the global `delivery_counter` variable to `0` inside persistent storage.
- Added logic to emit the `DeliveryContractInitialized` event payload securely on successful resolution.
- Refactored `test.rs` mock suite: Simplified legacy helper functions by registering the `MockEscrow` instantly inside `setup_test`.
- Delivered two new comprehensive unit tests ensuring validation of the event payload (`test_init_state_and_event`) and double-invocation handling (`test_double_init`).

## Cross-Contract Dependencies Introduced
No new crate dependencies were introduced; however, the logic solidifies the architectural boundary that a Delivery Contract now inherently depends on a valid Escrow Address during the bootstrap phase rather than at runtime lazily. 

## Test 
All unit tests have been strictly verified to pass locally matching the expected acceptance criteria.
