### PR TITLE
defined fleet structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fleet_management_contract"
+version = "0.1.0"
+dependencies = [
+ "shared_types",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/fleet_management_contract/Cargo.toml
+++ b/contracts/fleet_management_contract/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "fleet_management_contract"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "lib.rs"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+shared_types = { path = "../shared_types" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/fleet_management_contract/lib.rs
+++ b/contracts/fleet_management_contract/lib.rs
@@ -1,0 +1,88 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Symbol};
+
+pub type FleetId = u64;
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FleetProfile {
+    pub fleet_id: FleetId,
+    pub owner: Address,
+    pub treasury: Address,
+    pub total_active_drivers: u32,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    FleetCounter,
+    Fleet(FleetId),
+}
+
+#[contract]
+pub struct FleetManagementContract;
+
+#[contractimpl]
+impl FleetManagementContract {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("AlreadyInitialized");
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::FleetCounter, &0u64);
+
+        env.events().publish(
+            (Symbol::new(&env, "FleetContractInitialized"),),
+            admin,
+        );
+    }
+
+    pub fn register_fleet(env: Env, owner: Address, treasury: Address) -> FleetId {
+        owner.require_auth();
+
+        let mut counter: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::FleetCounter)
+            .unwrap_or(0);
+        counter += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::FleetCounter, &counter);
+
+        let fleet_id = counter;
+
+        let profile = FleetProfile {
+            fleet_id,
+            owner: owner.clone(),
+            treasury: treasury.clone(),
+            total_active_drivers: 0,
+        };
+
+        let key = DataKey::Fleet(fleet_id);
+        env.storage().persistent().set(&key, &profile);
+        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+
+        env.events().publish(
+            (Symbol::new(&env, "fleet_registered"),),
+            (fleet_id, owner, treasury),
+        );
+
+        fleet_id
+    }
+
+    pub fn get_fleet(env: Env, fleet_id: FleetId) -> FleetProfile {
+        let key = DataKey::Fleet(fleet_id);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic!("FleetNotFound"))
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/fleet_management_contract/test.rs
+++ b/contracts/fleet_management_contract/test.rs
@@ -1,0 +1,110 @@
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Events},
+    Address, Env, Symbol, TryFromVal,
+};
+
+fn setup_test() -> (Env, FleetManagementContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(FleetManagementContract, ());
+    let client = FleetManagementContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    (env, client, admin)
+}
+
+#[test]
+fn test_init_sets_admin_and_counter() {
+    let (env, client, admin) = setup_test();
+
+    let stored_admin: Address = env.as_contract(&client.address, || {
+        env.storage().instance().get(&DataKey::Admin).unwrap()
+    });
+    assert_eq!(stored_admin, admin);
+
+    let counter: u64 = env.as_contract(&client.address, || {
+        env.storage()
+            .persistent()
+            .get(&DataKey::FleetCounter)
+            .unwrap()
+    });
+    assert_eq!(counter, 0);
+}
+
+#[test]
+#[should_panic(expected = "AlreadyInitialized")]
+fn test_init_twice_panics() {
+    let (_env, client, admin) = setup_test();
+    client.init(&admin);
+}
+
+#[test]
+fn test_register_fleet_creates_profile_with_expected_fields() {
+    let (env, client, _admin) = setup_test();
+
+    let owner = Address::generate(&env);
+    let treasury = Address::generate(&env);
+
+    let fleet_id = client.register_fleet(&owner, &treasury);
+    assert_eq!(fleet_id, 1);
+
+    let profile = client.get_fleet(&fleet_id);
+    assert_eq!(profile.fleet_id, 1);
+    assert_eq!(profile.owner, owner);
+    assert_eq!(profile.treasury, treasury);
+    assert_eq!(profile.total_active_drivers, 0);
+}
+
+#[test]
+fn test_register_fleet_increments_counter() {
+    let (env, client, _admin) = setup_test();
+
+    let owner_a = Address::generate(&env);
+    let treasury_a = Address::generate(&env);
+    let owner_b = Address::generate(&env);
+    let treasury_b = Address::generate(&env);
+
+    let id_a = client.register_fleet(&owner_a, &treasury_a);
+    let id_b = client.register_fleet(&owner_b, &treasury_b);
+
+    assert_eq!(id_a, 1);
+    assert_eq!(id_b, 2);
+
+    let profile_b = client.get_fleet(&id_b);
+    assert_eq!(profile_b.owner, owner_b);
+    assert_eq!(profile_b.treasury, treasury_b);
+}
+
+#[test]
+fn test_register_fleet_emits_event() {
+    let (env, client, _admin) = setup_test();
+
+    let owner = Address::generate(&env);
+    let treasury = Address::generate(&env);
+    let fleet_id = client.register_fleet(&owner, &treasury);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+
+    assert_eq!(last_event.0, client.address.clone());
+
+    let topic0: Symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(topic0, Symbol::new(&env, "fleet_registered"));
+
+    let data: (FleetId, Address, Address) =
+        <(FleetId, Address, Address)>::try_from_val(&env, &last_event.2).unwrap();
+    assert_eq!(data, (fleet_id, owner, treasury));
+}
+
+#[test]
+#[should_panic(expected = "FleetNotFound")]
+fn test_get_fleet_unknown_id_panics() {
+    let (_env, client, _admin) = setup_test();
+    client.get_fleet(&999);
+}


### PR DESCRIPTION
# feat(fleet_management_contract): define data structure for enterprise fleets

Closes #53

## Summary

Introduces a new `fleet_management_contract` crate and defines the on-chain
data structure for Enterprise Fleets. The core deliverable is the
`FleetProfile` struct, which captures the identity and operational state of
each registered fleet (fleet ID, owner wallet, treasury wallet, and total
active drivers). A minimal contract surface (`init`, `register_fleet`,
`get_fleet`) is included to exercise the struct end-to-end and provide a
foundation for follow-up issues that will layer driver onboarding, payment
splitting, and fleet management operations on top of this structure.

## Changes

### New crate: `contracts/fleet_management_contract/`

- **`Cargo.toml`** — configured as a Soroban contract crate (`cdylib` + `rlib`),
  matching the conventions of `delivery_contract` and `escrow_contract`:
  - Depends on the workspace `soroban-sdk` and the local `shared_types` crate.
  - Enables `soroban-sdk/testutils` under `dev-dependencies` for unit tests.
  - Picked up automatically by the root workspace's `contracts/*` glob — no
    changes to the root `Cargo.toml` required.

- **`lib.rs`** — defines:
  - `FleetId` type alias (`u64`) for fleet identifiers.
  - `FleetProfile` struct with the four fields required by the issue:
    - `fleet_id: FleetId`
    - `owner: Address` — the wallet that owns/controls the fleet
    - `treasury: Address` — the wallet that receives fleet earnings
    - `total_active_drivers: u32` — running count of active drivers
  - `DataKey` enum for persistent/instance storage keys (`Admin`,
    `FleetCounter`, `Fleet(FleetId)`).
  - `FleetManagementContract` with three entry points:
    - `init(admin)` — one-shot admin setup with double-init guard.
    - `register_fleet(owner, treasury) -> FleetId` — auto-incrementing fleet
      ID, persists the profile, extends TTL, emits a `fleet_registered` event.
    - `get_fleet(fleet_id) -> FleetProfile` — read-only lookup, panics with
      `FleetNotFound` for unknown IDs.

- **`test.rs`** — six unit tests covering:
  1. `init` sets the admin and zeroes the fleet counter.
  2. Double `init` panics with `AlreadyInitialized`.
  3. `register_fleet` returns ID `1` and stores all four fields correctly.
  4. Sequential `register_fleet` calls increment the counter (1, 2, ...).
  5. `register_fleet` emits a `fleet_registered` event with the expected
     `(fleet_id, owner, treasury)` payload.
  6. `get_fleet` panics with `FleetNotFound` for an unknown ID.

## Design notes

- **Field types match the issue spec.** `Address` is used for both `owner` and
  `treasury` to allow the two roles to diverge — the entity controlling the
  fleet need not be the entity receiving its payouts. `total_active_drivers`
  is a `u32` since fleet sizes are bounded well below `2^32`.

- **`#[contracttype]` derives.** `FleetProfile` derives `Clone`, `Debug`, `Eq`,
  and `PartialEq`, mirroring `DeliveryRecord` in the delivery contract — these
  are required for storage round-trips and useful for assertions in tests.

- **Storage strategy mirrors the existing contracts.** Persistent storage is
  used for fleet records and the counter (with TTL extended on every write),
  while instance storage holds the admin reference. This keeps the new contract
  consistent with the patterns established in `delivery_contract`.

- **Scope discipline.** The PR intentionally implements only what the issue
  asks for — the struct definition plus the minimum surface area needed to
  prove it round-trips through storage and events. Driver registration,
  payment splitting, and fleet management operations are deferred to their
  respective follow-up issues.

## Verification

- `cargo build -p fleet_management_contract` — **succeeds**.
- `cargo check -p fleet_management_contract --tests` — **clean, no warnings**.
- `cargo test -p fleet_management_contract` — could not be executed in the
  local Windows dev environment because the host lacks the MSVC linker, and
  the GNU fallback hits MinGW's 65535-symbol DLL export limit when linking
  Soroban testutils (the existing `delivery_contract` test build fails
  identically with `ld: error: export ordinal too large`). The tests should
  be run in CI or on a host with MSVC build tools installed.

## Test plan

- [ ] CI runs `cargo test -p fleet_management_contract` and all six tests pass.
- [ ] Deploy the contract to Stellar testnet and invoke `init` followed by
      `register_fleet` with a real owner/treasury pair.
- [ ] Call `get_fleet` against the returned fleet ID and confirm all four
      fields match the values supplied at registration.
- [ ] Confirm a `fleet_registered` event is emitted with the expected
      `(fleet_id, owner, treasury)` payload.
- [ ] Confirm a second `init` call on the deployed contract reverts with
      `AlreadyInitialized`.

## Files changed

- `contracts/fleet_management_contract/Cargo.toml` (new)
- `contracts/fleet_management_contract/lib.rs` (new)
- `contracts/fleet_management_contract/test.rs` (new)
