### PR TITLE
feat: add register_user smart contract function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 name = "identity_reputation_contract"
 version = "0.1.0"
 dependencies = [
+ "shared_types",
  "soroban-sdk",
 ]
 

--- a/contracts/identity_reputation_contract/Cargo.toml
+++ b/contracts/identity_reputation_contract/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 path = "lib.rs"
 
 [dependencies]
 soroban-sdk = { workspace = true }
+shared_types = { path = "../shared_types" }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+

--- a/contracts/identity_reputation_contract/lib.rs
+++ b/contracts/identity_reputation_contract/lib.rs
@@ -1,1 +1,63 @@
+#![no_std]
 
+use shared_types::{SwiftChainError, UserProfile};
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env, Symbol};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    Admin,
+    UserProfile(Address),
+}
+
+#[contract]
+pub struct IdentityReputationContract;
+
+#[contractimpl]
+impl IdentityReputationContract {
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&env, SwiftChainError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::NotInitialized))
+    }
+
+    pub fn register_user(env: Env, user: Address) {
+        user.require_auth();
+        let key = DataKey::UserProfile(user.clone());
+        if env.storage().persistent().has(&key) {
+            panic_with_error!(&env, SwiftChainError::AlreadyInitialized);
+        }
+
+        let profile = UserProfile {
+            address: user.clone(),
+            registered_at: env.ledger().timestamp(),
+        };
+
+        env.storage().persistent().set(&key, &profile);
+        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+
+        env.events()
+            .publish((Symbol::new(&env, "user_registered"),), (user,));
+    }
+
+    pub fn get_user_profile(env: Env, user: Address) -> UserProfile {
+        let key = DataKey::UserProfile(user);
+        let profile: UserProfile = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::ProviderNotFound));
+        profile
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/identity_reputation_contract/test.rs
+++ b/contracts/identity_reputation_contract/test.rs
@@ -1,0 +1,57 @@
+use super::*;
+use shared_types::SwiftChainError;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup_env() -> (Env, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(IdentityReputationContract, ());
+    (env, contract_id)
+}
+
+#[test]
+fn test_register_user_success() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let user = Address::generate(&env);
+    client.register_user(&user);
+
+    let profile = client.get_user_profile(&user);
+    assert_eq!(profile.address, user);
+    assert_eq!(profile.registered_at, env.ledger().timestamp());
+}
+
+#[test]
+fn test_register_user_duplicate() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let user = Address::generate(&env);
+    client.register_user(&user);
+
+    let result = client.try_register_user(&user);
+    match result {
+        Err(Ok(err)) => assert_eq!(err, SwiftChainError::AlreadyInitialized.into()),
+        _ => panic!("Expected duplicate user registration to panic with AlreadyInitialized"),
+    }
+}
+
+#[test]
+fn test_get_user_profile_not_found() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let user = Address::generate(&env);
+    let result = client.try_get_user_profile(&user);
+    match result {
+        Err(Ok(err)) => assert_eq!(err, SwiftChainError::ProviderNotFound.into()),
+        _ => panic!("Expected missing user profile to return ProviderNotFound"),
+    }
+}

--- a/contracts/shared_types/lib.rs
+++ b/contracts/shared_types/lib.rs
@@ -195,8 +195,9 @@ pub struct EscrowRecord {
 #[cfg(test)]
 mod test {
     use super::{
-        DeliveryConfirmedEvent, DeliveryCreatedEvent, DeliveryDisputedEvent, DriverAssignedEvent,
-        EscrowFundedEvent, EscrowRefundedEvent, EscrowReleasedEvent, SwiftChainError, CargoDescriptor, CargoCategory, DeliveryMetadata,
+        CargoCategory, CargoDescriptor, DeliveryConfirmedEvent, DeliveryCreatedEvent,
+        DeliveryDisputedEvent, DeliveryMetadata, DriverAssignedEvent, EscrowFundedEvent,
+        EscrowRefundedEvent, EscrowReleasedEvent, SwiftChainError,
     };
     use soroban_sdk::{testutils::Address as _, Address, Env, String};
 
@@ -403,6 +404,13 @@ pub struct DriverProfile {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UserProfile {
+    pub address: Address,
+    pub registered_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CargoCategory {
     Documents,
     Electronics,
@@ -429,5 +437,3 @@ pub struct DeliveryMetadata {
     pub created_at: u64,
     pub estimated_delivery: u64,
 }
-
-


### PR DESCRIPTION
### Summary of implementation
Implemented the register_user and get_user_profile functions in the identity_reputation_contract contract.

### Storage implementation details
Used DataKey::UserProfile(Address) in Soroban persistent storage to store the user profiles. Added a TTL extension of 6 days.

### Authentication handling
Verified user authentication using user.require_auth() before storing.

### Tests added
Added unit tests for user registration, duplicate registration handling, and missing profiles.

Fixes #56