### PR TITLE
feat: add admin-controlled driver kyc status update

### DIFF
--- a/contracts/identity_reputation_contract/lib.rs
+++ b/contracts/identity_reputation_contract/lib.rs
@@ -60,6 +60,37 @@ impl IdentityReputationContract {
             .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::ProviderNotFound));
         profile
     }
+
+    pub fn update_driver_kyc_status(env: Env, admin: Address, driver: Address, kyc_verified: bool) {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::NotInitialized));
+
+        if admin != stored_admin {
+            panic_with_error!(&env, SwiftChainError::Unauthorized);
+        }
+
+        let key = DataKey::DriverProfile(driver.clone());
+        let mut profile: DriverProfile = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::ProviderNotFound));
+
+        profile.kyc_verified = kyc_verified;
+
+        env.storage().persistent().set(&key, &profile);
+        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+
+        env.events().publish(
+            (Symbol::new(&env, "kyc_status_updated"),),
+            (driver, kyc_verified),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/contracts/identity_reputation_contract/test.rs
+++ b/contracts/identity_reputation_contract/test.rs
@@ -58,3 +58,95 @@ fn test_get_driver_profile_not_found() {
         _ => panic!("Expected missing driver profile to return ProviderNotFound"),
     }
 }
+
+#[test]
+fn test_update_kyc_status_admin_approve() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver);
+
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.kyc_verified, false);
+
+    client.update_driver_kyc_status(&admin, &driver, &true);
+
+    let updated = client.get_driver_profile(&driver);
+    assert_eq!(updated.kyc_verified, true);
+    assert_eq!(updated.address, driver);
+    assert_eq!(updated.reputation_score, 50);
+}
+
+#[test]
+fn test_update_kyc_status_admin_revoke() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver);
+
+    client.update_driver_kyc_status(&admin, &driver, &true);
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.kyc_verified, true);
+
+    client.update_driver_kyc_status(&admin, &driver, &false);
+    let revoked = client.get_driver_profile(&driver);
+    assert_eq!(revoked.kyc_verified, false);
+}
+
+#[test]
+fn test_update_kyc_status_unauthorized() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver);
+
+    let attacker = Address::generate(&env);
+    let result = client.try_update_driver_kyc_status(&attacker, &driver, &true);
+    match result {
+        Err(Ok(err)) => assert_eq!(err, SwiftChainError::Unauthorized.into()),
+        _ => panic!("Expected non-admin caller to fail with Unauthorized"),
+    }
+}
+
+#[test]
+fn test_update_kyc_status_driver_not_found() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    let result = client.try_update_driver_kyc_status(&admin, &driver, &true);
+    match result {
+        Err(Ok(err)) => assert_eq!(err, SwiftChainError::ProviderNotFound.into()),
+        _ => panic!("Expected missing driver to return ProviderNotFound"),
+    }
+}
+
+#[test]
+fn test_update_kyc_status_persists_other_fields() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver);
+
+    client.update_driver_kyc_status(&admin, &driver, &true);
+
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.kyc_verified, true);
+    assert_eq!(profile.deliveries_completed, 0);
+    assert_eq!(profile.reputation_score, 50);
+    assert_eq!(profile.address, driver);
+}


### PR DESCRIPTION
## Summary

- Implements `update_driver_kyc_status` in `contracts/identity_reputation_contract`
- Allows a designated admin to approve or revoke KYC verification for registered drivers on-chain
- Builds on `register_driver` (which initialises `kyc_verified: false` by default)

## Admin Authentication Logic

The function accepts an `admin: Address` argument and calls `admin.require_auth()` to enforce Soroban-level auth. It then fetches the stored admin from instance storage and compares — any caller who is not the stored admin panics with `SwiftChainError::Unauthorized`. This dual-check (require_auth + identity comparison) ensures neither the auth mechanism nor the storage check can be bypassed independently.

## KYC Update Behaviour

- Loads the driver's `DriverProfile` from persistent storage
- Sets `profile.kyc_verified` to the supplied boolean (`true` to approve, `false` to revoke)
- Re-writes the profile and refreshes the persistent TTL (518 400 ledgers)
- Emits a `kyc_status_updated` event carrying `(driver, kyc_verified)`
- All other profile fields (`reputation_score`, `deliveries_completed`, `registered_at`) are left unchanged

## Security Considerations

- Only the initialised admin address can call this function
- Attempting to call before `init` panics with `NotInitialized`
- Attempting to call for an unregistered driver panics with `ProviderNotFound`
- KYC status can be revoked as well as granted, keeping the admin in full control

## Tests Added

| Test | What it verifies |
|------|-----------------|
| `test_update_kyc_status_admin_approve` | Admin sets `kyc_verified = true`; value persists |
| `test_update_kyc_status_admin_revoke` | Admin revokes KYC after approval; value returns to `false` |
| `test_update_kyc_status_unauthorized` | Non-admin caller panics with `Unauthorized` |
| `test_update_kyc_status_driver_not_found` | Updating a non-existent driver panics with `ProviderNotFound` |
| `test_update_kyc_status_persists_other_fields` | KYC update does not mutate reputation score, deliveries, or address |

All 8 tests in the contract (including pre-existing `register_driver` tests) pass.

Fixes #58