### PR TITLE
feat: implement dispute lifecycle testing with evidence and split fund integration tests

### DIFF
--- a/contracts/delivery_contract/lib.rs
+++ b/contracts/delivery_contract/lib.rs
@@ -169,7 +169,7 @@ impl DeliveryContract {
         let _: () = env.invoke_contract(
             &escrow_address,
             &soroban_sdk::Symbol::new(&env, "refund_escrow"),
-            soroban_sdk::vec![&env, delivery_id.into_val(&env)],
+            soroban_sdk::vec![&env, sender.into_val(&env), delivery_id.into_val(&env)],
         );
 
         delivery.status = DeliveryStatus::Cancelled;
@@ -275,7 +275,7 @@ impl DeliveryContract {
         let _: () = env.invoke_contract(
             &escrow_address,
             &soroban_sdk::Symbol::new(&env, "release_escrow"),
-            soroban_sdk::vec![&env, delivery_id.into_val(&env)],
+            soroban_sdk::vec![&env, recipient.into_val(&env), delivery_id.into_val(&env)],
         );
 
         delivery.status = DeliveryStatus::Delivered;
@@ -344,7 +344,7 @@ impl DeliveryContract {
         let _: () = env.invoke_contract(
             &escrow_address,
             &Symbol::new(&env, "raise_dispute"),
-            soroban_sdk::vec![&env, delivery_id.into_val(&env)],
+            soroban_sdk::vec![&env, caller.into_val(&env), delivery_id.into_val(&env)],
         );
 
         let timestamp = env.ledger().timestamp();

--- a/contracts/delivery_contract/test.rs
+++ b/contracts/delivery_contract/test.rs
@@ -14,15 +14,15 @@ pub struct MockEscrow;
 
 #[contractimpl]
 impl MockEscrow {
-    pub fn refund_escrow(_env: Env, delivery_id: DeliveryId) {
+    pub fn refund_escrow(_env: Env, _caller: Address, delivery_id: DeliveryId) {
         if delivery_id == 999 {
             panic!("Escrow failure simulated");
         }
     }
 
-    pub fn release_escrow(_env: Env, _delivery_id: DeliveryId) {}
+    pub fn release_escrow(_env: Env, _caller: Address, _delivery_id: DeliveryId) {}
 
-    pub fn raise_dispute(_env: Env, delivery_id: DeliveryId) {
+    pub fn raise_dispute(_env: Env, _caller: Address, delivery_id: DeliveryId) {
         if delivery_id == 777 {
             panic!("Escrow raise_dispute failure simulated");
         }

--- a/contracts/dispute_resolution_contract/lib.rs
+++ b/contracts/dispute_resolution_contract/lib.rs
@@ -1,6 +1,9 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, Env, IntoVal, Symbol};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, panic_with_error, Address, BytesN, Env, IntoVal, Symbol,
+    Vec,
+};
 use shared_types::SwiftChainError;
 use delivery_contract::{DeliveryContractClient, DeliveryStatus};
 
@@ -22,6 +25,7 @@ pub struct DisputeCase {
     pub status: DisputeStatus,
     pub raised_at: u64,
     pub raised_by: Address,
+    pub evidence_hashes: Vec<BytesN<32>>,
 }
 
 #[contracttype]
@@ -142,6 +146,7 @@ impl DisputeResolutionContract {
             status: DisputeStatus::Open,
             raised_at: env.ledger().timestamp(),
             raised_by: caller.clone(),
+            evidence_hashes: Vec::new(&env),
         };
 
         env.storage().persistent().set(&dispute_key, &dispute);
@@ -150,6 +155,43 @@ impl DisputeResolutionContract {
         env.events().publish(
             (Symbol::new(&env, "dispute_raised"), delivery_id),
             (caller, delivery_id),
+        );
+    }
+
+    pub fn add_evidence_hash(
+        env: Env,
+        caller: Address,
+        delivery_id: DeliveryId,
+        evidence_hash: BytesN<32>,
+    ) {
+        caller.require_auth();
+
+        let dispute_key = DataKey::Dispute(delivery_id);
+        let mut dispute: DisputeCase = env
+            .storage()
+            .persistent()
+            .get(&dispute_key)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::DeliveryNotFound));
+
+        if dispute.status != DisputeStatus::Open {
+            panic_with_error!(&env, SwiftChainError::InvalidState);
+        }
+
+        let delivery_contract_addr = Self::get_delivery_contract(env.clone());
+        let delivery_client = DeliveryContractClient::new(&env, &delivery_contract_addr);
+        let delivery = delivery_client.get_delivery(&delivery_id);
+
+        if caller != delivery.sender && caller != delivery.recipient {
+            panic_with_error!(&env, SwiftChainError::Unauthorized);
+        }
+
+        dispute.evidence_hashes.push_back(evidence_hash.clone());
+        env.storage().persistent().set(&dispute_key, &dispute);
+        env.storage().persistent().extend_ttl(&dispute_key, 518400, 518400);
+
+        env.events().publish(
+            (Symbol::new(&env, "evidence_added"), delivery_id),
+            (caller, delivery_id, evidence_hash),
         );
     }
 
@@ -190,6 +232,56 @@ impl DisputeResolutionContract {
 
         env.events().publish(
             (Symbol::new(&env, "dispute_resolved_refund"), delivery_id),
+            (caller, delivery_id),
+        );
+    }
+
+    pub fn resolve_dispute_split_funds(
+        env: Env,
+        caller: Address,
+        delivery_id: DeliveryId,
+        sender_share_bps: u32,
+    ) {
+        caller.require_auth();
+        if !Self::is_admin(env.clone(), caller.clone()) {
+            panic_with_error!(&env, SwiftChainError::Unauthorized);
+        }
+
+        let dispute_key = DataKey::Dispute(delivery_id);
+        let mut dispute: DisputeCase = env
+            .storage()
+            .persistent()
+            .get(&dispute_key)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::DeliveryNotFound));
+
+        if dispute.status != DisputeStatus::Open {
+            panic_with_error!(&env, SwiftChainError::InvalidState);
+        }
+
+        dispute.status = DisputeStatus::Split;
+        env.storage().persistent().set(&dispute_key, &dispute);
+        env.storage().persistent().extend_ttl(&dispute_key, 518400, 518400);
+
+        let escrow_addr = Self::get_escrow_contract(env.clone());
+        let escrow_client = escrow_contract::EscrowContractClient::new(&env, &escrow_addr);
+        let escrow = escrow_client.get_escrow(&delivery_id);
+
+        if escrow.status == shared_types::EscrowStatus::Paused {
+            use soroban_sdk::IntoVal;
+            let _: () = env.invoke_contract(
+                &escrow_addr,
+                &Symbol::new(&env, "resolve_dispute_split"),
+                soroban_sdk::vec![
+                    &env,
+                    caller.into_val(&env),
+                    delivery_id.into_val(&env),
+                    sender_share_bps.into_val(&env),
+                ],
+            );
+        }
+
+        env.events().publish(
+            (Symbol::new(&env, "dispute_resolved_split"), delivery_id),
             (caller, delivery_id),
         );
     }

--- a/contracts/dispute_resolution_contract/test.rs
+++ b/contracts/dispute_resolution_contract/test.rs
@@ -2,6 +2,7 @@ use super::*;
 use soroban_sdk::{
     contract, contractimpl,
     testutils::{Address as _, Ledger},
+    token::{Client as TokenClient, StellarAssetClient},
     Address, Env, String,
 };
 use shared_types::SwiftChainError;
@@ -47,6 +48,14 @@ impl MockEscrowContract {
             } else {
                 record.status = shared_types::EscrowStatus::Refunded;
             }
+            env.storage().instance().set(&delivery_id, &record);
+        }
+    }
+
+    pub fn resolve_dispute_split(env: Env, _caller: Address, delivery_id: u64, _sender_share_bps: u32) {
+        if env.storage().instance().has(&delivery_id) {
+            let mut record: shared_types::EscrowRecord = env.storage().instance().get(&delivery_id).unwrap();
+            record.status = shared_types::EscrowStatus::Refunded;
             env.storage().instance().set(&delivery_id, &record);
         }
     }
@@ -228,6 +237,7 @@ fn test_raise_dispute_active_delivery() {
     assert_eq!(case.delivery_id, 1);
     assert_eq!(case.status, DisputeStatus::Open);
     assert_eq!(case.raised_by, sender);
+    assert_eq!(case.evidence_hashes.len(), 0);
 }
 
 #[test]
@@ -322,4 +332,118 @@ fn test_unauthorized_resolve_dispute_fails() {
 
     // Attacker (sender) tries to resolve dispute
     dispute_client.resolve_dispute_refund_sender(&sender, &5);
+}
+
+#[test]
+fn test_add_evidence_hash_success() {
+    let (env, _admin, sender, recipient, _driver, delivery_id, _escrow_id, dispute_client) = setup_test();
+
+    let delivery_record = create_mock_delivery_record(&env, 6, sender.clone(), recipient.clone(), delivery_contract::DeliveryStatus::Active, None);
+    set_mock_delivery(&env, &delivery_id, 6, &delivery_record);
+
+    dispute_client.raise_dispute(&sender, &6);
+
+    let evidence_hash1 = soroban_sdk::BytesN::from_array(&env, &[1; 32]);
+    let evidence_hash2 = soroban_sdk::BytesN::from_array(&env, &[2; 32]);
+
+    // Sender adds evidence
+    dispute_client.add_evidence_hash(&sender, &6, &evidence_hash1);
+    // Recipient adds evidence
+    dispute_client.add_evidence_hash(&recipient, &6, &evidence_hash2);
+
+    let case = dispute_client.get_dispute(&6);
+    assert_eq!(case.evidence_hashes.len(), 2);
+    assert_eq!(case.evidence_hashes.get(0).unwrap(), evidence_hash1);
+    assert_eq!(case.evidence_hashes.get(1).unwrap(), evidence_hash2);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #1)")] // SwiftChainError::Unauthorized
+fn test_add_evidence_unauthorized_fails() {
+    let (env, _admin, sender, recipient, _driver, delivery_id, _escrow_id, dispute_client) = setup_test();
+
+    let delivery_record = create_mock_delivery_record(&env, 7, sender.clone(), recipient.clone(), delivery_contract::DeliveryStatus::Active, None);
+    set_mock_delivery(&env, &delivery_id, 7, &delivery_record);
+
+    dispute_client.raise_dispute(&sender, &7);
+
+    let attacker = Address::generate(&env);
+    let evidence_hash = soroban_sdk::BytesN::from_array(&env, &[3; 32]);
+
+    dispute_client.add_evidence_hash(&attacker, &7, &evidence_hash);
+}
+
+#[test]
+fn test_integration_resolve_dispute_split_funds() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let driver = Address::generate(&env);
+
+    // Register real contracts
+    let delivery_contract_id = env.register(delivery_contract::DeliveryContract, ());
+    let escrow_contract_id = env.register(escrow_contract::EscrowContract, ());
+    let dispute_resolution_id = env.register(DisputeResolutionContract, ());
+
+    let delivery_client = delivery_contract::DeliveryContractClient::new(&env, &delivery_contract_id);
+    let escrow_client = escrow_contract::EscrowContractClient::new(&env, &escrow_contract_id);
+    let dispute_client = DisputeResolutionContractClient::new(&env, &dispute_resolution_id);
+
+    // Register stellar asset contract for token
+    let token = env.register_stellar_asset_contract_v2(admin.clone()).address();
+
+    // Init contracts
+    escrow_client.init(&admin, &token, &0);
+    delivery_client.init(&admin, &escrow_contract_id);
+    dispute_client.init(&admin, &delivery_contract_id, &escrow_contract_id, &3600);
+
+    // Mint tokens to sender
+    StellarAssetClient::new(&env, &token).mint(&sender, &1000);
+
+    // Create delivery
+    let metadata = {
+        let cargo = shared_types::CargoDescriptor {
+            weight_grams: 500,
+            category: shared_types::CargoCategory::Electronics,
+            fragile: true,
+        };
+        shared_types::DeliveryMetadata {
+            delivery_id: 0,
+            origin: String::from_str(&env, "Origin"),
+            destination: String::from_str(&env, "Destination"),
+            cargo_description: cargo,
+            created_at: env.ledger().timestamp(),
+            estimated_delivery: env.ledger().timestamp() + 3600,
+        }
+    };
+    let delivery_id_val = delivery_client.create_delivery(&sender, &recipient, &metadata);
+
+    // Create escrow
+    escrow_client.create_escrow(&sender, &recipient, &driver, &delivery_id_val, &token, &1000);
+
+    // Assign driver to make delivery Active
+    delivery_client.assign_driver(&admin, &delivery_id_val, &driver);
+
+    // Raise dispute
+    dispute_client.raise_dispute(&sender, &delivery_id_val);
+
+    // Verify escrow is paused
+    let escrow = escrow_client.get_escrow(&delivery_id_val);
+    assert_eq!(escrow.status, shared_types::EscrowStatus::Paused);
+
+    // Resolve split (60% sender, 40% driver)
+    dispute_client.resolve_dispute_split_funds(&admin, &delivery_id_val, &6000);
+
+    // Verify local dispute is Split
+    let case = dispute_client.get_dispute(&delivery_id_val);
+    assert_eq!(case.status, DisputeStatus::Split);
+
+    // Verify token balances
+    let sender_balance = TokenClient::new(&env, &token).balance(&sender);
+    let driver_balance = TokenClient::new(&env, &token).balance(&driver);
+    assert_eq!(sender_balance, 600); // 60% of 1000 refunded
+    assert_eq!(driver_balance, 400); // 40% of 1000 paid to driver
 }

--- a/contracts/escrow_contract/lib.rs
+++ b/contracts/escrow_contract/lib.rs
@@ -437,6 +437,54 @@ impl EscrowContract {
         );
     }
 
+    pub fn resolve_dispute_split(
+        env: Env,
+        caller: Address,
+        delivery_id: u64,
+        sender_share_bps: u32,
+    ) {
+        caller.require_auth();
+        require_admin(&env, &caller);
+        if sender_share_bps > 10000 {
+            panic_with_error!(&env, EscrowError::InvalidFee);
+        }
+        let mut record = load_escrow(&env, delivery_id);
+        if record.status != EscrowStatus::Paused {
+            panic_with_error!(&env, EscrowError::InvalidState);
+        }
+        let contract_balance =
+            token::Client::new(&env, &record.token).balance(&env.current_contract_address());
+        if contract_balance < record.amount {
+            panic_with_error!(&env, EscrowError::InsufficientFunds);
+        }
+
+        let sender_amount = record.amount.saturating_mul(sender_share_bps as i128) / 10000;
+        let driver_amount = record.amount.saturating_sub(sender_amount);
+
+        if sender_amount > 0 {
+            token::Client::new(&env, &record.token).transfer(
+                &env.current_contract_address(),
+                &record.sender,
+                &sender_amount,
+            );
+        }
+        if driver_amount > 0 {
+            token::Client::new(&env, &record.token).transfer(
+                &env.current_contract_address(),
+                &record.driver,
+                &driver_amount,
+            );
+        }
+
+        record.status = EscrowStatus::Refunded;
+        save_escrow(&env, delivery_id, &record);
+
+        env.events().publish(
+            (events::dispute_resolved(&env), delivery_id),
+            (caller.clone(), caller),
+        );
+    }
+
     pub fn get_escrow(env: Env, delivery_id: u64) -> EscrowRecord {
         if !env
             .storage()


### PR DESCRIPTION
## Description

This PR implements evidence hashing tracking, custom split payouts for dispute resolution, and verifies them with unit and integration tests.

### Key Implementations

1. **Dispute Lifecycle & Evidence**:
   - Added the `evidence_hashes` field to the `DisputeCase` struct to track files/documents uploaded during a dispute.
   - Implemented `add_evidence_hash(env, caller, delivery_id, evidence_hash)` to verify the caller's participation (sender or recipient) and append evidence to the active dispute case.
   - Added unit tests checking the state machine changes and successful evidence uploads.

2. **Integration Tests & Split Payouts**:
   - Implemented `resolve_dispute_split` in the `EscrowContract` to support dividing escrowed tokens between the sender and driver based on admin input.
   - Implemented `resolve_dispute_split_funds` in the `DisputeResolutionContract` to coordinate state tracking and trigger split payouts.
   - Added multi-contract integration tests validating the end-to-end flow of creating a delivery, raising a dispute, executing a split payout resolution, and verifying respective account balances.
   - Resolved pre-existing cross-contract call mismatches in `delivery_contract` when calling the updated `escrow_contract` APIs.

### Related Issues

Closes #86
Closes #87
