### PR TITLE
feat: implement register_fleet, add_driver_to_fleet, accept_fleet_invite and remove_driver_from_fleet for fleet management contract

### DIFF
--- a/contracts/fleet_management_contract/Cargo.toml
+++ b/contracts/fleet_management_contract/Cargo.toml
@@ -9,3 +9,6 @@ path = "lib.rs"
 
 [dependencies]
 soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/fleet_management_contract/lib.rs
+++ b/contracts/fleet_management_contract/lib.rs
@@ -1,1 +1,294 @@
+#![no_std]
 
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
+};
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+pub type FleetId = u64;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum FleetError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    Unauthorized = 3,
+    FleetNotFound = 4,
+    DriverAlreadyInvited = 5,
+    InviteNotFound = 6,
+    DriverAlreadyActive = 7,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DriverFleetStatus {
+    /// Driver has been invited but has not yet accepted.
+    Pending,
+    /// Driver has accepted and is an active member of the fleet.
+    Active,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FleetProfile {
+    pub fleet_id: FleetId,
+    pub owner: Address,
+    pub treasury: Address,
+    pub total_active_drivers: u32,
+}
+
+/// Persistent storage keys for the fleet management contract.
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    /// Instance key — stores the contract administrator address.
+    Admin,
+    /// Persistent key — monotonically incrementing fleet counter.
+    FleetCounter,
+    /// Persistent key — fleet profile keyed by fleet id.
+    Fleet(FleetId),
+    /// Persistent key — driver's status within a fleet (Pending | Active).
+    DriverFleet(FleetId, Address),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct FleetManagementContract;
+
+#[contractimpl]
+impl FleetManagementContract {
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    /// Initialise the contract, setting the admin and zeroing the fleet counter.
+    pub fn init(env: Env, admin: Address) {
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic_with_error!(&env, FleetError::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::FleetCounter, &0u64);
+    }
+
+    // ── Issue #67 — register_fleet ────────────────────────────────────────────
+
+    /// Register a new fleet, designating an owner and a treasury wallet.
+    ///
+    /// The caller (owner) must sign the transaction.  Returns the new fleet id.
+    pub fn register_fleet(env: Env, owner: Address, treasury: Address) -> FleetId {
+        owner.require_auth();
+
+        // Bump and persist the fleet counter.
+        let counter_key = DataKey::FleetCounter;
+        let current: u64 = env
+            .storage()
+            .persistent()
+            .get(&counter_key)
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::NotInitialized));
+
+        let fleet_id: FleetId = current + 1;
+        env.storage().persistent().set(&counter_key, &fleet_id);
+
+        // Build and store the fleet profile.
+        let profile = FleetProfile {
+            fleet_id,
+            owner: owner.clone(),
+            treasury: treasury.clone(),
+            total_active_drivers: 0,
+        };
+
+        let fleet_key = DataKey::Fleet(fleet_id);
+        env.storage().persistent().set(&fleet_key, &profile);
+        env.storage()
+            .persistent()
+            .extend_ttl(&fleet_key, 518400, 518400);
+
+        // Emit event: topic = "fleet_registered", data = (fleet_id, owner, treasury).
+        env.events().publish(
+            (Symbol::new(&env, "fleet_registered"),),
+            (fleet_id, owner, treasury),
+        );
+
+        fleet_id
+    }
+
+    /// Return the stored profile for a fleet.  Panics with `FleetNotFound` when
+    /// no fleet with that id exists.
+    pub fn get_fleet(env: Env, fleet_id: FleetId) -> FleetProfile {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Fleet(fleet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::FleetNotFound))
+    }
+
+    // ── Issue #68 — add_driver_to_fleet ───────────────────────────────────────
+
+    /// Invite a driver to a fleet.  Only the fleet owner may call this.
+    ///
+    /// Stores a `Pending` invite for `driver` under this fleet.  The driver
+    /// must later call `accept_fleet_invite` to become active.
+    pub fn add_driver_to_fleet(env: Env, fleet_id: FleetId, driver: Address) {
+        let profile: FleetProfile = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Fleet(fleet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::FleetNotFound));
+
+        // Require fleet-owner authorisation.
+        profile.owner.require_auth();
+
+        let invite_key = DataKey::DriverFleet(fleet_id, driver.clone());
+
+        // Guard: do not overwrite an existing invite or active membership.
+        if env.storage().persistent().has(&invite_key) {
+            let existing: DriverFleetStatus = env
+                .storage()
+                .persistent()
+                .get(&invite_key)
+                .unwrap();
+            match existing {
+                DriverFleetStatus::Pending => {
+                    panic_with_error!(&env, FleetError::DriverAlreadyInvited)
+                }
+                DriverFleetStatus::Active => {
+                    panic_with_error!(&env, FleetError::DriverAlreadyActive)
+                }
+            }
+        }
+
+        // Record the pending invite.
+        env.storage()
+            .persistent()
+            .set(&invite_key, &DriverFleetStatus::Pending);
+        env.storage()
+            .persistent()
+            .extend_ttl(&invite_key, 518400, 518400);
+
+        // Emit event.
+        env.events().publish(
+            (Symbol::new(&env, "driver_invited"),),
+            (fleet_id, driver),
+        );
+    }
+
+    // ── Issue #69 — accept_fleet_invite ───────────────────────────────────────
+
+    /// Accept a pending fleet invite.  The driver themselves must sign this
+    /// transaction.  Transitions status from `Pending` → `Active` and
+    /// increments `total_active_drivers` on the fleet profile.
+    pub fn accept_fleet_invite(env: Env, fleet_id: FleetId, driver: Address) {
+        // Driver must authorise.
+        driver.require_auth();
+
+        // Verify the fleet exists.
+        let mut profile: FleetProfile = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Fleet(fleet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::FleetNotFound));
+
+        let invite_key = DataKey::DriverFleet(fleet_id, driver.clone());
+
+        // Verify there is a pending invite.
+        let status: DriverFleetStatus = env
+            .storage()
+            .persistent()
+            .get(&invite_key)
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::InviteNotFound));
+
+        match status {
+            DriverFleetStatus::Active => panic_with_error!(&env, FleetError::DriverAlreadyActive),
+            DriverFleetStatus::Pending => {}
+        }
+
+        // Promote driver to active.
+        env.storage()
+            .persistent()
+            .set(&invite_key, &DriverFleetStatus::Active);
+        env.storage()
+            .persistent()
+            .extend_ttl(&invite_key, 518400, 518400);
+
+        // Update active driver count on the fleet profile.
+        profile.total_active_drivers += 1;
+        let fleet_key = DataKey::Fleet(fleet_id);
+        env.storage().persistent().set(&fleet_key, &profile);
+        env.storage()
+            .persistent()
+            .extend_ttl(&fleet_key, 518400, 518400);
+
+        // Emit event.
+        env.events().publish(
+            (Symbol::new(&env, "invite_accepted"),),
+            (fleet_id, driver),
+        );
+    }
+
+    // ── Issue #70 — remove_driver_from_fleet ──────────────────────────────────
+
+    /// Remove a driver from a fleet.  Either the fleet owner or the driver
+    /// themselves may call this function (bilateral severance).
+    ///
+    /// `caller` must be either the fleet owner or the driver being removed.
+    /// Deletes the driver's fleet record and, if the driver was `Active`,
+    /// decrements `total_active_drivers` on the fleet profile.
+    pub fn remove_driver_from_fleet(env: Env, fleet_id: FleetId, caller: Address, driver: Address) {
+        let mut profile: FleetProfile = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Fleet(fleet_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::FleetNotFound));
+
+        // Verify caller is authorised: must be either the fleet owner or the driver.
+        let is_owner = caller == profile.owner;
+        let is_driver = caller == driver;
+        if !is_owner && !is_driver {
+            panic_with_error!(&env, FleetError::Unauthorized);
+        }
+
+        // The caller must sign this transaction.
+        caller.require_auth();
+
+        let invite_key = DataKey::DriverFleet(fleet_id, driver.clone());
+
+        let status: DriverFleetStatus = env
+            .storage()
+            .persistent()
+            .get(&invite_key)
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::InviteNotFound));
+
+        // Decrement active driver count only when the driver was active.
+        if status == DriverFleetStatus::Active && profile.total_active_drivers > 0 {
+            profile.total_active_drivers -= 1;
+            let fleet_key = DataKey::Fleet(fleet_id);
+            env.storage().persistent().set(&fleet_key, &profile);
+        }
+
+        // Remove the driver's fleet record.
+        env.storage().persistent().remove(&invite_key);
+
+        // Emit event.
+        env.events().publish(
+            (Symbol::new(&env, "driver_removed"),),
+            (fleet_id, driver),
+        );
+    }
+
+    /// Return the status of a driver within a fleet, or `None` if no record
+    /// exists.  Useful for off-chain queries and integration tests.
+    pub fn get_driver_fleet_status(
+        env: Env,
+        fleet_id: FleetId,
+        driver: Address,
+    ) -> Option<DriverFleetStatus> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::DriverFleet(fleet_id, driver))
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contracts/fleet_management_contract/test.rs
+++ b/contracts/fleet_management_contract/test.rs
@@ -19,6 +19,19 @@ fn setup_test() -> (Env, FleetManagementContractClient<'static>, Address) {
     (env, client, admin)
 }
 
+/// Helper: register a fleet and return (fleet_id, owner, treasury).
+fn register_fleet(
+    env: &Env,
+    client: &FleetManagementContractClient,
+) -> (FleetId, Address, Address) {
+    let owner = Address::generate(env);
+    let treasury = Address::generate(env);
+    let fleet_id = client.register_fleet(&owner, &treasury);
+    (fleet_id, owner, treasury)
+}
+
+// ── Issue #67 tests ───────────────────────────────────────────────────────────
+
 #[test]
 fn test_init_sets_admin_and_counter() {
     let (env, client, admin) = setup_test();
@@ -38,7 +51,7 @@ fn test_init_sets_admin_and_counter() {
 }
 
 #[test]
-#[should_panic(expected = "AlreadyInitialized")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_init_twice_panics() {
     let (_env, client, admin) = setup_test();
     client.init(&admin);
@@ -103,8 +116,241 @@ fn test_register_fleet_emits_event() {
 }
 
 #[test]
-#[should_panic(expected = "FleetNotFound")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_get_fleet_unknown_id_panics() {
     let (_env, client, _admin) = setup_test();
     client.get_fleet(&999);
+}
+
+// ── Issue #68 tests — add_driver_to_fleet ────────────────────────────────────
+
+#[test]
+fn test_add_driver_stores_pending_invite() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+
+    let status = client.get_driver_fleet_status(&fleet_id, &driver);
+    assert_eq!(status, Some(DriverFleetStatus::Pending));
+}
+
+#[test]
+fn test_add_driver_emits_driver_invited_event() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+
+    let topic0: Symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(topic0, Symbol::new(&env, "driver_invited"));
+
+    let data: (FleetId, Address) =
+        <(FleetId, Address)>::try_from_val(&env, &last_event.2).unwrap();
+    assert_eq!(data, (fleet_id, driver));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_add_driver_twice_panics() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    // Second invite to the same driver must panic.
+    client.add_driver_to_fleet(&fleet_id, &driver);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_add_driver_to_unknown_fleet_panics() {
+    let (env, client, _admin) = setup_test();
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&999, &driver);
+}
+
+// ── Issue #69 tests — accept_fleet_invite ────────────────────────────────────
+
+#[test]
+fn test_accept_invite_promotes_driver_to_active() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+
+    let status = client.get_driver_fleet_status(&fleet_id, &driver);
+    assert_eq!(status, Some(DriverFleetStatus::Active));
+}
+
+#[test]
+fn test_accept_invite_increments_active_driver_count() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver_a = Address::generate(&env);
+    let driver_b = Address::generate(&env);
+
+    client.add_driver_to_fleet(&fleet_id, &driver_a);
+    client.add_driver_to_fleet(&fleet_id, &driver_b);
+
+    client.accept_fleet_invite(&fleet_id, &driver_a);
+    let profile = client.get_fleet(&fleet_id);
+    assert_eq!(profile.total_active_drivers, 1);
+
+    client.accept_fleet_invite(&fleet_id, &driver_b);
+    let profile = client.get_fleet(&fleet_id);
+    assert_eq!(profile.total_active_drivers, 2);
+}
+
+#[test]
+fn test_accept_invite_emits_event() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+
+    let topic0: Symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(topic0, Symbol::new(&env, "invite_accepted"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_accept_invite_without_prior_invite_panics() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    // No invite was sent — must panic.
+    client.accept_fleet_invite(&fleet_id, &driver);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_accept_invite_twice_panics() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+    // Accepting again must panic.
+    client.accept_fleet_invite(&fleet_id, &driver);
+}
+
+// ── Issue #70 tests — remove_driver_from_fleet ───────────────────────────────
+
+#[test]
+fn test_remove_active_driver_decrements_count() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+
+    // Owner removes the driver.
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver);
+
+    let profile = client.get_fleet(&fleet_id);
+    assert_eq!(profile.total_active_drivers, 0);
+
+    let status = client.get_driver_fleet_status(&fleet_id, &driver);
+    assert_eq!(status, None);
+}
+
+#[test]
+fn test_remove_pending_driver_does_not_affect_active_count() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    // Driver has NOT accepted — still Pending.
+
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver);
+
+    let profile = client.get_fleet(&fleet_id);
+    assert_eq!(profile.total_active_drivers, 0);
+
+    let status = client.get_driver_fleet_status(&fleet_id, &driver);
+    assert_eq!(status, None);
+}
+
+#[test]
+fn test_driver_can_remove_themselves() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+
+    // Driver removes themselves (caller == driver).
+    client.remove_driver_from_fleet(&fleet_id, &driver, &driver);
+
+    let status = client.get_driver_fleet_status(&fleet_id, &driver);
+    assert_eq!(status, None);
+}
+
+#[test]
+fn test_remove_driver_emits_event() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+
+    let topic0: Symbol = Symbol::try_from_val(&env, &last_event.1.get(0).unwrap()).unwrap();
+    assert_eq!(topic0, Symbol::new(&env, "driver_removed"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_remove_driver_unknown_fleet_panics() {
+    let (env, client, _admin) = setup_test();
+    let caller = Address::generate(&env);
+    let driver = Address::generate(&env);
+    client.remove_driver_from_fleet(&999, &caller, &driver);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_remove_driver_not_in_fleet_panics() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    // Driver was never invited — must panic.
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_remove_driver_unauthorized_caller_panics() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+
+    let random_caller = Address::generate(&env);
+    // random_caller is neither owner nor driver — must panic.
+    client.remove_driver_from_fleet(&fleet_id, &random_caller, &driver);
 }


### PR DESCRIPTION

## Fleet Management Contract — Core Functions

Implements all four core fleet lifecycle functions in `contracts/fleet_management_contract`.

---

### Changes

#### `register_fleet(owner, treasury) → FleetId`

Allows an SME to register a fleet and designate a treasury wallet address. Requires the owner to sign the transaction. Increments a persistent fleet counter, stores a `FleetProfile` (with `fleet_id`, `owner`, `treasury`, and `total_active_drivers: 0`), and emits a `fleet_registered` event.

Closes #67

---

#### `add_driver_to_fleet(fleet_id, driver)`

Allows a fleet owner to invite a driver's wallet address to their fleet. Requires fleet owner authorisation. Stores a `DriverFleetStatus::Pending` record for the driver under that fleet and emits a `driver_invited` event. Panics if the driver already has a pending invite or is already active.

Closes #68

---

#### `accept_fleet_invite(fleet_id, driver)`

Requires the individual driver to sign a transaction accepting their inclusion in a fleet. Verifies a `Pending` invite exists for the driver, transitions their status to `Active`, increments `total_active_drivers` on the `FleetProfile`, and emits an `invite_accepted` event. Panics if no invite exists or the driver is already active.

Closes #69

---

#### `remove_driver_from_fleet(fleet_id, caller, driver)`

Allows either the fleet owner or the driver themselves to sever the relationship. The `caller` parameter is explicitly checked against both the fleet owner and the driver before a single `require_auth()` is called — the correct Soroban pattern for bilateral authorisation. If the driver was `Active`, `total_active_drivers` is decremented. The driver's fleet record is removed and a `driver_removed` event is emitted.

Closes #70

---

### Tests

22 unit tests added/updated — all passing.

```
test result: ok. 22 passed; 0 failed; 0 ignored
```

Covers: init, fleet registration, counter increments, event emissions, driver invite/accept/remove flows, active count tracking, duplicate guards, fleet-not-found, unauthorized caller, and bilateral remove auth.
