### PR TITLE
feat(identity-reputation): implement reputation management functions

### DIFF
--- a/contracts/identity_reputation_contract/lib.rs
+++ b/contracts/identity_reputation_contract/lib.rs
@@ -11,6 +11,17 @@ pub enum DataKey {
     AuthorizedContract(Address),
 }
 
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DriverTier {
+    Bronze,
+    Silver,
+    Gold,
+}
+
+const MAX_REPUTATION: u32 = 100;
+const ENTERPRISE_THRESHOLD: u32 = 75;
+
 #[contract]
 pub struct IdentityReputationContract;
 
@@ -115,6 +126,112 @@ impl IdentityReputationContract {
             (Symbol::new(&env, "kyc_status_updated"),),
             (driver, kyc_verified),
         );
+    }
+
+    pub fn increase_reputation(
+        env: Env,
+        caller: Address,
+        driver: Address,
+        delivery_id: u64,
+        weight_grams: u32,
+        fragile: bool,
+    ) {
+        caller.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::NotInitialized));
+
+        let is_admin = caller == stored_admin;
+        let is_authorized = Self::is_authorized_contract(env.clone(), caller.clone());
+
+        if !is_admin && !is_authorized {
+            panic_with_error!(&env, SwiftChainError::Unauthorized);
+        }
+
+        let key = DataKey::DriverProfile(driver.clone());
+        let mut profile: DriverProfile = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::ProviderNotFound));
+
+        let mut points: u32 = 5;
+        if weight_grams > 5000 {
+            points += 3;
+        }
+        if fragile {
+            points += 2;
+        }
+
+        profile.reputation_score = (profile.reputation_score + points).min(MAX_REPUTATION);
+        profile.deliveries_completed += 1;
+
+        env.storage().persistent().set(&key, &profile);
+        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+
+        env.events().publish(
+            (Symbol::new(&env, "reputation_increased"),),
+            (driver, delivery_id, points),
+        );
+    }
+
+    pub fn decrease_reputation(
+        env: Env,
+        caller: Address,
+        driver: Address,
+        points: u32,
+    ) {
+        caller.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::NotInitialized));
+
+        let is_admin = caller == stored_admin;
+        let is_authorized = Self::is_authorized_contract(env.clone(), caller.clone());
+
+        if !is_admin && !is_authorized {
+            panic_with_error!(&env, SwiftChainError::Unauthorized);
+        }
+
+        let key = DataKey::DriverProfile(driver.clone());
+        let mut profile: DriverProfile = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| panic_with_error!(&env, SwiftChainError::ProviderNotFound));
+
+        profile.reputation_score = profile.reputation_score.saturating_sub(points);
+
+        env.storage().persistent().set(&key, &profile);
+        env.storage().persistent().extend_ttl(&key, 518400, 518400);
+
+        env.events().publish(
+            (Symbol::new(&env, "reputation_decreased"),),
+            (driver, points),
+        );
+    }
+
+    pub fn get_driver_tier(env: Env, driver: Address) -> DriverTier {
+        let profile = Self::get_driver_profile(env, driver);
+        let score = profile.reputation_score;
+        if score >= 75 {
+            DriverTier::Gold
+        } else if score >= 50 {
+            DriverTier::Silver
+        } else {
+            DriverTier::Bronze
+        }
+    }
+
+    pub fn is_eligible_for_enterprise(env: Env, driver: Address) -> bool {
+        let profile = Self::get_driver_profile(env, driver);
+        profile.reputation_score >= ENTERPRISE_THRESHOLD
     }
 }
 

--- a/contracts/identity_reputation_contract/test.rs
+++ b/contracts/identity_reputation_contract/test.rs
@@ -106,6 +106,255 @@ fn test_increase_reputation_cap_at_100() {
 }
 
 #[test]
+fn test_decrease_reputation_success() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    client.decrease_reputation(&admin, &driver, &10u32);
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 40); // 50 - 10
+}
+
+#[test]
+fn test_decrease_reputation_floor_at_zero() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Deduct more than the current score
+    client.decrease_reputation(&admin, &driver, &200u32);
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 0);
+}
+
+#[test]
+fn test_decrease_reputation_unauthorized() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver);
+
+    let attacker = Address::generate(&env);
+    let result = client.try_decrease_reputation(&attacker, &driver, &10u32);
+    match result {
+        Err(Ok(err)) => assert_eq!(err, SwiftChainError::Unauthorized.into()),
+        _ => panic!("Expected unauthorized caller to panic with Unauthorized"),
+    }
+}
+
+#[test]
+fn test_decrease_reputation_missing_driver() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    let result = client.try_decrease_reputation(&admin, &driver, &10u32);
+    match result {
+        Err(Ok(err)) => assert_eq!(err, SwiftChainError::ProviderNotFound.into()),
+        _ => panic!("Expected missing driver to return ProviderNotFound"),
+    }
+}
+
+#[test]
+fn test_decrease_reputation_authorized_contract() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let delivery_contract_addr = Address::generate(&env);
+    client.set_authorized_contract(&admin, &delivery_contract_addr, &true);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver);
+
+    client.decrease_reputation(&delivery_contract_addr, &driver, &5u32);
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 45); // 50 - 5
+}
+
+#[test]
+fn test_get_driver_tier_silver_at_registration() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    let tier = client.get_driver_tier(&driver);
+    assert_eq!(tier, DriverTier::Silver);
+}
+
+#[test]
+fn test_get_driver_tier_bronze() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Deduct enough to fall below 50
+    client.decrease_reputation(&admin, &driver, &15u32);
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 35);
+
+    let tier = client.get_driver_tier(&driver);
+    assert_eq!(tier, DriverTier::Bronze);
+}
+
+#[test]
+fn test_get_driver_tier_gold() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Increase to reach Gold (>= 75)
+    for i in 0..3 {
+        client.increase_reputation(&admin, &driver, &(200 + i), &6000u32, &true);
+    }
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 80); // 50 + 10 + 10 + 10
+
+    let tier = client.get_driver_tier(&driver);
+    assert_eq!(tier, DriverTier::Gold);
+}
+
+#[test]
+fn test_get_driver_tier_boundary_silver_to_gold() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Increase to exactly 75 (Gold threshold)
+    for i in 0..5 {
+        client.increase_reputation(&admin, &driver, &(300 + i), &1000u32, &false); // +5 each
+    }
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 75);
+
+    let tier = client.get_driver_tier(&driver);
+    assert_eq!(tier, DriverTier::Gold);
+}
+
+#[test]
+fn test_is_eligible_for_enterprise_true() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Reach the enterprise threshold (75)
+    for i in 0..5 {
+        client.increase_reputation(&admin, &driver, &(400 + i), &1000u32, &false);
+    }
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 75);
+
+    assert!(client.is_eligible_for_enterprise(&driver));
+}
+
+#[test]
+fn test_is_eligible_for_enterprise_false() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50 (below 75 threshold)
+
+    assert!(!client.is_eligible_for_enterprise(&driver));
+}
+
+#[test]
+fn test_is_eligible_for_enterprise_after_decrease() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Raise to Gold tier
+    for i in 0..5 {
+        client.increase_reputation(&admin, &driver, &(500 + i), &1000u32, &false);
+    }
+    assert!(client.is_eligible_for_enterprise(&driver)); // score = 75, eligible
+
+    // Penalize below threshold
+    client.decrease_reputation(&admin, &driver, &5u32);
+    assert!(!client.is_eligible_for_enterprise(&driver)); // score = 70, no longer eligible
+}
+
+#[test]
+fn test_reputation_bounds_cannot_exceed_100() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Repeatedly apply maximum bonus to ensure we never exceed 100
+    for i in 0..20 {
+        client.increase_reputation(&admin, &driver, &(600 + i), &6000u32, &true);
+    }
+
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 100);
+}
+
+#[test]
+fn test_reputation_bounds_cannot_drop_below_zero() {
+    let (env, contract_id) = setup_env();
+    let client = IdentityReputationContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+
+    let driver = Address::generate(&env);
+    client.register_driver(&driver); // starts at 50
+
+    // Repeatedly apply large penalties
+    for _ in 0..10 {
+        client.decrease_reputation(&admin, &driver, &50u32);
+    }
+
+    let profile = client.get_driver_profile(&driver);
+    assert_eq!(profile.reputation_score, 0);
+}
+
+#[test]
 fn test_update_kyc_status_admin_approve() {
     let (env, contract_id) = setup_env();
     let client = IdentityReputationContractClient::new(&env, &contract_id);


### PR DESCRIPTION
Implements the following functions in the identity_reputation_contract:

- increase_reputation: awards points on successful delivery with bonuses for
  heavy cargo (>5000g, +3pts) and fragile items (+2pts) on top of the base
  5-point reward. Only callable by the admin or an authorized contract.
  Increments deliveries_completed and caps the score at 100.

- decrease_reputation: deducts a specified number of points for late
  deliveries or lost disputes. Only callable by the admin or an authorized
  contract. Uses saturating subtraction so the score cannot drop below 0.

- get_driver_tier: classifies a driver as Bronze (score < 50), Silver
  (50–74), or Gold (>= 75) based on their current reputation_score.
  Returns the new DriverTier contracttype enum.

- is_eligible_for_enterprise: returns true when a driver's reputation_score
  meets or exceeds the enterprise threshold of 75, allowing the
  delivery_contract to gate enterprise-level assignments.

Bounds enforcement (issue #63) is applied inside both increase_reputation
(.min(100)) and decrease_reputation (.saturating_sub) so scores are
permanently constrained to [0, 100] regardless of the caller-supplied delta.

24 tests pass covering:
- success paths and bonus calculation for increase
- floor/ceiling enforcement for both increase and decrease
- unauthorized and missing-driver error paths for all mutating functions
- authorized-contract delegation for both increase and decrease
- all three tier boundaries including the exact 75 boundary
- enterprise eligibility toggling as score crosses the threshold

closes #60
closes #61
closes #62
closes #63
