### PR TITLE
feat: expose get_payout_address, link fleet to identity, add roster and treasury routing tests 

### DIFF
--- a/contracts/fleet_management_contract/lib.rs
+++ b/contracts/fleet_management_contract/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, Symbol,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, Address, Env, IntoVal,
+    Symbol,
 };
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -45,6 +46,8 @@ pub struct FleetProfile {
 pub enum DataKey {
     /// Instance key — stores the contract administrator address.
     Admin,
+    /// Instance key — optional address of the identity_reputation_contract.
+    IdentityContract,
     /// Persistent key — monotonically incrementing fleet counter.
     FleetCounter,
     /// Persistent key — fleet profile keyed by fleet id.
@@ -73,11 +76,31 @@ impl FleetManagementContract {
             .set(&DataKey::FleetCounter, &0u64);
     }
 
+    /// Configure the address of the identity_reputation_contract.  Admin only.
+    /// Once set, `register_fleet` will automatically create an identity profile
+    /// for the fleet owner via a cross-contract call.
+    pub fn set_identity_contract(env: Env, admin: Address, identity_contract: Address) {
+        admin.require_auth();
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, FleetError::NotInitialized));
+        if admin != stored_admin {
+            panic_with_error!(&env, FleetError::Unauthorized);
+        }
+        env.storage()
+            .instance()
+            .set(&DataKey::IdentityContract, &identity_contract);
+    }
+
     // ── Issue #67 — register_fleet ────────────────────────────────────────────
 
     /// Register a new fleet, designating an owner and a treasury wallet.
     ///
     /// The caller (owner) must sign the transaction.  Returns the new fleet id.
+    /// If an identity contract is configured, automatically creates an identity
+    /// profile for the owner via a cross-contract call.
     pub fn register_fleet(env: Env, owner: Address, treasury: Address) -> FleetId {
         owner.require_auth();
 
@@ -105,6 +128,20 @@ impl FleetManagementContract {
         env.storage()
             .persistent()
             .extend_ttl(&fleet_key, 518400, 518400);
+
+        // Issue #73 — if identity contract is configured, register the fleet
+        // owner as a driver in the identity_reputation_contract.
+        if let Some(identity_addr) = env
+            .storage()
+            .instance()
+            .get::<DataKey, Address>(&DataKey::IdentityContract)
+        {
+            let _: () = env.invoke_contract(
+                &identity_addr,
+                &Symbol::new(&env, "register_driver"),
+                soroban_sdk::vec![&env, owner.clone().into_val(&env)],
+            );
+        }
 
         // Emit event: topic = "fleet_registered", data = (fleet_id, owner, treasury).
         env.events().publish(
@@ -303,6 +340,32 @@ impl FleetManagementContract {
             (Symbol::new(&env, "driver_removed"),),
             (fleet_id, driver),
         );
+    }
+
+    // ── Issue #72 — get_payout_address ───────────────────────────────────────
+
+    /// Return the address that the escrow_contract should route funds to for a
+    /// given driver and fleet.
+    ///
+    /// Returns the fleet's treasury if the driver is an active member of that
+    /// fleet, otherwise returns the driver's own address.
+    pub fn get_payout_address(env: Env, driver: Address, fleet_id: FleetId) -> Address {
+        let status: Option<DriverFleetStatus> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::DriverFleet(fleet_id, driver.clone()));
+
+        match status {
+            Some(DriverFleetStatus::Active) => {
+                let profile: FleetProfile = env
+                    .storage()
+                    .persistent()
+                    .get(&DataKey::Fleet(fleet_id))
+                    .unwrap_or_else(|| panic_with_error!(&env, FleetError::FleetNotFound));
+                profile.treasury
+            }
+            _ => driver,
+        }
     }
 
     /// Return the status of a driver within a fleet, or `None` if no record

--- a/contracts/fleet_management_contract/test.rs
+++ b/contracts/fleet_management_contract/test.rs
@@ -377,3 +377,195 @@ fn test_remove_driver_unauthorized_caller_panics() {
     // random_caller is neither owner nor driver — must panic.
     client.remove_driver_from_fleet(&fleet_id, &random_caller, &driver);
 }
+
+// ── Issue #75 tests — Fleet Roster Management ────────────────────────────────
+
+#[test]
+fn test_roster_full_lifecycle_add_accept_remove() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+
+    // Add: driver starts as Pending.
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    assert_eq!(
+        client.get_driver_fleet_status(&fleet_id, &driver),
+        Some(DriverFleetStatus::Pending)
+    );
+
+    // Accept: driver transitions to Active, count increments.
+    client.accept_fleet_invite(&fleet_id, &driver);
+    assert_eq!(
+        client.get_driver_fleet_status(&fleet_id, &driver),
+        Some(DriverFleetStatus::Active)
+    );
+    assert_eq!(client.get_fleet(&fleet_id).total_active_drivers, 1);
+
+    // Remove: record deleted, count decrements.
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver);
+    assert_eq!(client.get_driver_fleet_status(&fleet_id, &driver), None);
+    assert_eq!(client.get_fleet(&fleet_id).total_active_drivers, 0);
+}
+
+#[test]
+fn test_roster_multiple_drivers_independent_states() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver_a = Address::generate(&env);
+    let driver_b = Address::generate(&env);
+    let driver_c = Address::generate(&env);
+
+    client.add_driver_to_fleet(&fleet_id, &driver_a);
+    client.add_driver_to_fleet(&fleet_id, &driver_b);
+    client.add_driver_to_fleet(&fleet_id, &driver_c);
+
+    // Accept only a and b.
+    client.accept_fleet_invite(&fleet_id, &driver_a);
+    client.accept_fleet_invite(&fleet_id, &driver_b);
+
+    assert_eq!(client.get_fleet(&fleet_id).total_active_drivers, 2);
+    assert_eq!(
+        client.get_driver_fleet_status(&fleet_id, &driver_c),
+        Some(DriverFleetStatus::Pending)
+    );
+
+    // Remove driver_a; driver_b and driver_c unaffected.
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver_a);
+    assert_eq!(client.get_fleet(&fleet_id).total_active_drivers, 1);
+    assert_eq!(
+        client.get_driver_fleet_status(&fleet_id, &driver_b),
+        Some(DriverFleetStatus::Active)
+    );
+    assert_eq!(
+        client.get_driver_fleet_status(&fleet_id, &driver_c),
+        Some(DriverFleetStatus::Pending)
+    );
+}
+
+#[test]
+fn test_roster_driver_can_leave_voluntarily() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+
+    // Driver removes themselves.
+    client.remove_driver_from_fleet(&fleet_id, &driver, &driver);
+
+    assert_eq!(client.get_driver_fleet_status(&fleet_id, &driver), None);
+    assert_eq!(client.get_fleet(&fleet_id).total_active_drivers, 0);
+}
+
+#[test]
+fn test_roster_re_invite_after_removal() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver);
+
+    // Should be possible to invite the same driver again after removal.
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    assert_eq!(
+        client.get_driver_fleet_status(&fleet_id, &driver),
+        Some(DriverFleetStatus::Pending)
+    );
+}
+
+// ── Issue #76 tests — Treasury Routing Logic ─────────────────────────────────
+
+#[test]
+fn test_get_payout_address_returns_treasury_for_active_driver() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+
+    let payout = client.get_payout_address(&driver, &fleet_id);
+    assert_eq!(payout, treasury);
+}
+
+#[test]
+fn test_get_payout_address_returns_driver_when_not_in_fleet() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    // Driver has no record in the fleet.
+    let payout = client.get_payout_address(&driver, &fleet_id);
+    assert_eq!(payout, driver);
+}
+
+#[test]
+fn test_get_payout_address_returns_driver_for_pending_invite() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    // Invite is Pending — not yet accepted.
+
+    let payout = client.get_payout_address(&driver, &fleet_id);
+    assert_eq!(payout, driver);
+}
+
+#[test]
+fn test_get_payout_address_returns_driver_after_removal() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+    client.remove_driver_from_fleet(&fleet_id, &owner, &driver);
+
+    // After removal the driver should receive their own address.
+    let payout = client.get_payout_address(&driver, &fleet_id);
+    assert_eq!(payout, driver);
+}
+
+#[test]
+fn test_get_payout_address_treasury_updates_are_reflected() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, owner, _old_treasury) = register_fleet(&env, &client);
+
+    let driver = Address::generate(&env);
+    client.add_driver_to_fleet(&fleet_id, &driver);
+    client.accept_fleet_invite(&fleet_id, &driver);
+
+    let new_treasury = Address::generate(&env);
+    client.update_fleet_treasury(&owner, &fleet_id, &new_treasury);
+
+    let payout = client.get_payout_address(&driver, &fleet_id);
+    assert_eq!(payout, new_treasury);
+}
+
+#[test]
+fn test_get_payout_address_multiple_drivers_same_fleet() {
+    let (env, client, _admin) = setup_test();
+    let (fleet_id, _owner, treasury) = register_fleet(&env, &client);
+
+    let driver_a = Address::generate(&env);
+    let driver_b = Address::generate(&env);
+    let driver_c = Address::generate(&env);
+
+    client.add_driver_to_fleet(&fleet_id, &driver_a);
+    client.add_driver_to_fleet(&fleet_id, &driver_b);
+    client.add_driver_to_fleet(&fleet_id, &driver_c);
+
+    // Only a and b accept; c stays pending.
+    client.accept_fleet_invite(&fleet_id, &driver_a);
+    client.accept_fleet_invite(&fleet_id, &driver_b);
+
+    assert_eq!(client.get_payout_address(&driver_a, &fleet_id), treasury);
+    assert_eq!(client.get_payout_address(&driver_b, &fleet_id), treasury);
+    assert_eq!(client.get_payout_address(&driver_c, &fleet_id), driver_c);
+}


### PR DESCRIPTION
feat: implement get_payout_address, identity linking, and fleet management tests

closes #72
closes #73
closes #75
closes #76

## Summary

- **#72 get_payout_address**: Added `get_payout_address(driver, fleet_id) -> Address` to `FleetManagementContract`. Returns the fleet treasury when the driver holds an `Active` membership in the given fleet, otherwise returns the driver's own address. This is the routing hook the `escrow_contract` calls to determine where to send funds.

- **#73 Link Fleet to Identity**: Added `set_identity_contract(admin, identity_contract)` to store the address of the deployed `identity_reputation_contract`. When `register_fleet` is called and an identity contract is configured, it makes a cross-contract call to `register_driver` on that contract, automatically creating an identity profile for the fleet owner. The call is opt-in (no-op if the identity contract address has not been set), which preserves backwards compatibility with all existing tests.

- **#75 Fleet Roster Management Tests**: Added four tests covering the full driver lifecycle — add → accept → remove, multiple independent drivers, voluntary driver self-removal, and re-invitation after removal.

- **#76 Treasury Routing Tests**: Added six tests for `get_payout_address` — active driver returns treasury, unregistered driver returns self, pending-only driver returns self, driver after removal returns self, updated treasury is reflected, and multiple drivers in the same fleet with mixed statuses.

## Test plan

- All 34 unit tests pass (`cargo test -p fleet_management_contract`).
- No existing tests were modified; all prior behaviour is preserved.
- The identity contract cross-contract call is only triggered when `set_identity_contract` has been called, so existing tests that do not configure it are unaffected.
